### PR TITLE
Piloting Dependency Detection Action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,3 +16,20 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm run compile
+
+    - name: Dependency Detection setup
+      uses: actions/checkout@v2
+      with:
+        repository: github/dependency-detection
+        ref: releases/v1
+        token: ${{ secrets.GH_PRIVATE_REPO_PAT }}
+        path: .github/actions/dependency-detection
+  
+      # This is an experimental action that Microsoft OSE + GH Dependency Graph are piloting.
+      #
+      # If it ever encounters issues, see PR that introduced this for contacts to reach out to and
+      # feel free to disable this step to unblock builds.
+    - name: Dependency Detection
+      uses: ./.github/actions/dependency-detection
+      with:
+        token: ${{ github.token }}


### PR DESCRIPTION
## Build time detection pilot
### Description
​
Build time detection feature will allow GitHub to accurately collect an inventory of the components necessary to build your project. It is based on the same concept of Component Detection in ADO. As of today, we report to engineers in their build logs any introduced vulnerabilities. This delta will be shown within your PR and default branch builds. This feature was done as a collaboration between MS Open Source Engineering and GitHub's Dependency Graph team.
​
This repo was selected because it meets our piloting criteria. Pilot repositories should:
- Be on Github.com
- Be Microsoft-owned
- Be private/internal
- Have pull request Action checks configured
​
This PR adds 2 steps to your regular CI workflow.
1. Clones our private repo containing this new pilot action.
1. Runs the action.
​
### Repo Admin TODO
- Add secret to pull GitHub Action from our private repository (https://github.com/github/dependency-detection).

Cloning our private repo will require a PAT named `GH_PRIVATE_REPO_PAT` which we can provide. Someone who has permissions to add secrets to the repo should reach out to either [grvillic](mailto:grvillic@microsoft.com), [tevoinea](mailto:tevoinea@microsoft.com) or via slack in `#msft-ose`. We have plans to open source this detector later this year, but as of now we are using a PAT to fetch it.
​
### Escape Hatch
​
If something goes wrong, please reach out to either of the 2 emails above and do not hesitate to remove the actions from your workflows to unblock.

### FAQ
**​Q: Will this break my PR builds if I already had vulnerable components?**
A: No, we only pick up deltas between PR and latest master build. If a vulnerable package is found, we just drop a warning in your build logs, we do not enforce any broken builds just yet.

**Q: Will this register components in my Component Governance?**
A: No, this project is separate from Component Governance and will only register components in GitHub.

**Q: How to fix Dependency Detection Setup step failure with `Error: Input required and not supplied: token`?**
A: If this log still happens AFTER repo admin added the secret to repository, it means we (PR authors) don't have write access. Our PR checks won't pass because we don't have privileges to pull secrets in our workflow updates. To fix this, a repository admin needs to recreate this exact same PR.

**Q: I see a warning after the first run with `Warning: Failed to apply policy`?**
A: This is expected to happen the first time only. It happens because the build does not have a baseline to compare against.
Another way this log could happen is if you haven't enabled Dependency Graph in your repo, most internal repos have this enabled by default. You can confirm by going to your repo's `/network/dependencies`, top menu "Insights -> Dependency Graph" (explicit message "the dependency graph is not enabled").