### PR TITLE
chore: use in process 'which' instead of spawning sub process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/parser": "^7.16.12",
         "@babel/traverse": "^7.16.10",
         "stack-utils": "^2.0.5",
+        "which": "^2.0.2",
         "ws": "^8.4.2"
       },
       "devDependencies": {
@@ -24,6 +25,7 @@
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.14",
         "@types/stack-utils": "^2.0.1",
+        "@types/which": "^2.0.1",
         "@types/ws": "^8.2.2",
         "@typescript-eslint/eslint-plugin": "^5.10.2",
         "@typescript-eslint/parser": "^5.10.2",
@@ -534,6 +536,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -2883,8 +2891,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4405,7 +4412,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5059,6 +5065,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
     "@types/ws": {
@@ -6690,8 +6702,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -7846,7 +7857,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.14",
     "@types/stack-utils": "^2.0.1",
+    "@types/which": "^2.0.1",
     "@types/ws": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
@@ -101,6 +102,7 @@
     "@babel/parser": "^7.16.12",
     "@babel/traverse": "^7.16.10",
     "stack-utils": "^2.0.5",
+    "which": "^2.0.2",
     "ws": "^8.4.2"
   }
 }

--- a/src/playwrightTest.ts
+++ b/src/playwrightTest.ts
@@ -20,7 +20,8 @@ import { ReporterServer } from './reporterServer';
 import { debugSessionName } from './debugSessionName';
 import { Entry, StepBeginParams, StepEndParams, TestBeginParams, TestEndParams } from './oopReporter';
 import type { TestError } from './reporter';
-import { findInPath, spawnAsync } from './utils';
+import { spawnAsync } from './utils';
+import which from 'which';
 import * as vscodeTypes from './vscodeTypes';
 
 export type TestConfig = {
@@ -233,12 +234,7 @@ export class PlaywrightTest {
     if (this._pathToNodeJS)
       return this._pathToNodeJS;
 
-    let node = await findInPath('node');
-    // When extension host boots, it does not have the right env set, so we might need to wait.
-    for (let i = 0; i < 5 && !node; ++i) {
-      await new Promise(f => setTimeout(f, 1000));
-      node = await findInPath('node');
-    }
+    const node = await which('node');
     if (!node)
       throw new Error('Unable to launch `node`, make sure it is in your PATH');
     this._pathToNodeJS = node;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,51 +30,6 @@ export function createGuid(): string {
   return crypto.randomBytes(16).toString('hex');
 }
 
-export async function findInPath(program: string): Promise<string | undefined> {
-  let locator: string;
-  if (process.platform === 'win32') {
-    const windir = process.env['WINDIR'] || 'C:\\Windows';
-    locator = path.join(windir, 'System32', 'where.exe');
-  } else {
-    locator = '/usr/bin/which';
-  }
-
-  try {
-    if (fs.existsSync(locator)) {
-      const stdout = await spawnAsync(locator, [program]);
-      const lines = stdout.split(/\r?\n/);
-
-      if (process.platform === 'win32') {
-        // return the first path that has a executable extension
-        const executableExtensions = String(process.env['PATHEXT'] || '.exe')
-            .toUpperCase()
-            .split(';');
-
-        for (const candidate of lines) {
-          const ext = path.extname(candidate).toUpperCase();
-          if (ext && executableExtensions.includes(ext))
-            return candidate;
-
-        }
-      } else {
-        // return the first path
-        if (lines.length > 0)
-          return lines[0];
-
-      }
-      return undefined;
-    } else {
-      // do not report failure if 'locator' app doesn't exist
-    }
-    return program;
-  } catch (err) {
-    // fall through
-  }
-
-  // fail
-  return undefined;
-}
-
 export function ansiToHtml(text: string): string {
   let isOpen = false;
   let hasTags = false;

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import { EventEmitter } from './events';
 import minimatch from 'minimatch';
 import { spawn } from 'child_process';
-import { findInPath } from '../../src/utils';
+import which from 'which';
 
 class Uri {
   scheme = 'file';
@@ -469,7 +469,7 @@ class Debug {
     for (const factory of this.dapFactories)
       this._dapSniffer = factory.createDebugAdapterTracker(session);
     this._didStartDebugSession.fire(session);
-    const node = await findInPath('node');
+    const node = await which('node');
     const subprocess = spawn(node, [configuration.program, ...configuration.args], {
       cwd: configuration.cwd,
       stdio: 'pipe',


### PR DESCRIPTION
It seems popular, maintained and better than spawning a subprocess see [here](https://www.npmjs.com/package/which).

This fixes the flaky tests too.