### PR TITLE
chore: make Playwright install work on NPM 6

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -63,7 +63,7 @@ export async function installPlaywright(vscode: vscodeTypes.VSCode) {
   if (result.includes(installDepsItem))
     args.push('--install-deps');
 
-  terminal.sendText(`npm init --yes playwright@latest -- --quiet ${args.join(' ')}`, true);
+  terminal.sendText(`npm init playwright@latest --yes -- --quiet ${args.join(' ')}`, true);
 }
 
 export async function installBrowsers(vscode: vscodeTypes.VSCode, model: TestModel) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-vscode/issues/220

Tested via ` docker run -it node:14 /bin/bash `.