### PR TITLE
chore: detect pnp workspaces and lookup playwright-core using yarn's PnP API

### DIFF
--- a/src/playwrightTest.ts
+++ b/src/playwrightTest.ts
@@ -71,11 +71,12 @@ export class PlaywrightTest {
       try {
         const pwtCoreInfo = await this._runNode([
           '-e',
-          'const pnpapi = require("pnpapi"); ' +
-          'const locators = pnpapi.getAllLocators().filter(locator => locator.name === "playwright-core"); ' +
-          'if (locators.length === 0) { process.exit(1); } ' +
-          'const info = pnpapi.getPackageInformation(locators[0]); ' +
-          'console.log(JSON.stringify({version: locators[0].reference, ...info}));'
+          `const pnpapi = require('pnpapi');
+          const pwCoreLocator = pnpapi.getAllLocators().find(locator => locator.name === 'playwright-core');
+          if (!pwCoreLocator)
+            process.exit(1);
+          const info = pnpapi.getPackageInformation(pwCoreLocator);
+          console.log(JSON.stringify({version: pwCoreLocator.reference, ...info}));`
         ],
         path.dirname(configFilePath),
         getPnPEnvVariables(workspaceFolder));


### PR DESCRIPTION
Since there have been some issues regarding repositories which do not offer a traditional `node_modules` folder (#133)  I tried to get this extension working for repositories with yarn-v3 and PnP. 

Did not find a contribution guide so let me know if something needs to change or if you do not accept any foreign contributions. 