### PR TITLE
Fix Install Playwright Browser with deps command

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -97,7 +97,7 @@ export async function installBrowsers(vscode: vscodeTypes.VSCode, model: TestMod
   terminal.show();
 
   const args: string[] = [];
-  const installCommand = result.includes(installDepsItem) ? 'install-with-deps' : 'install';
+  const installCommand = result.includes(installDepsItem) ? 'install --with-deps' : 'install';
   if (result.includes(chromiumItem))
     args.push('chromium');
   if (result.includes(firefoxItem))


### PR DESCRIPTION
`Install Playwright Browser` command currently fails when choosing to include linux dependencies.

```
$ npx playwright install-with-deps chromium firefox webkit
error: unknown command 'install-with-deps'
```

PR updated the command to call use `install --with-deps` which is the correct command for (at least) 1.19+