### PR TITLE
chore: do not force workers=1 when under test

### DIFF
--- a/src/playwrightTest.ts
+++ b/src/playwrightTest.ts
@@ -163,7 +163,7 @@ export class PlaywrightTest {
     ];
     if (this._reusedBrowser.browserServerEnv(false) && !allArgs.includes('--headed') && !this._isUnderTest)
       allArgs.push('--headed');
-    if (this._isUnderTest || args.includes('--headed'))
+    if (args.includes('--headed'))
       allArgs.push('--workers', '1');
     // Disable original reporters when listing files.
     if (mode === 'list')

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -768,6 +768,7 @@ test('should report project-specific failures', async ({ activate }) => {
   const { vscode, testController } = await activate({
     'playwright.config.js': `module.exports = {
       testDir: 'tests',
+      workers: 1,
       projects: [
         { 'name': 'projectA' },
         { 'name': 'projectB' },


### PR DESCRIPTION
Running with `repeat-each=5`, this is not flaky, except for a single test.