### PR TITLE
fix: allow settings action clicks next to label

### DIFF
--- a/media/settingsView.css
+++ b/media/settingsView.css
@@ -67,6 +67,7 @@ label {
   display: flex;
   align-items: center;
   cursor: inherit;
+  flex: auto;
 }
 
 div.separator {


### PR DESCRIPTION
The issue is that customers often click on the text next to the label, which has `cursor: pointer`, so they think it will open codegen, but in reality, this is not doing anything, because there is no click handler attached.

<img width="333" alt="image" src="https://github.com/microsoft/playwright-vscode/assets/17984549/523c7ced-2e17-4415-9d58-665bd3f45792">

This is the issue which a bunch of our lab users encountered during the demo at MSBuild.