### PR TITLE
fix: horizontal scrolling in webview

### DIFF
--- a/media/settingsView.css
+++ b/media/settingsView.css
@@ -38,6 +38,7 @@ svg {
   padding-left: 8px;
   display: flex;
   align-items: center;
+  box-sizing: border-box;
   width: 100%;
   white-space: nowrap;
   flex: 0;


### PR DESCRIPTION
Thats how it was before (green = padding):

<img width="400" alt="image" src="https://github.com/microsoft/playwright-vscode/assets/17984549/59cffd7f-ba92-40c5-92d9-ddd69f1f806d">

Issue was that the horizontal scrollbar was always shown.