### PR TITLE
fix(install): make it possible to install without selected items

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -41,7 +41,7 @@ export async function installPlaywright(vscode: vscodeTypes.VSCode) {
     title: 'Install Playwright',
     canPickMany: true,
   });
-  if (!result?.length)
+  if (result === undefined)
     return;
 
   const terminal = vscode.window.createTerminal({


### PR DESCRIPTION
Short recap, thats our install screen:

<img width="777" alt="image" src="https://github.com/microsoft/playwright-vscode/assets/17984549/ef2e5f08-2771-43d1-9720-67181f64ec78">

If the user presses, Escape, then the return value is `undefined`. Otherwise its an array, and empty if the user does not selected anything.

Fixes https://github.com/microsoft/playwright/issues/23910