### PR TITLE
fix: Node.js is not in PATH and didn't retry

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,11 +142,11 @@ export async function findNode(): Promise<string> {
   if (pathToNodeJS)
     return pathToNodeJS;
 
-  let node = await which('node');
+  let node = await which('node').catch(e => undefined);
   // When extension host boots, it does not have the right env set, so we might need to wait.
   for (let i = 0; i < 5 && !node; ++i) {
     await new Promise(f => setTimeout(f, 1000));
-    node = await which('node');
+    node = await which('node').catch(e => undefined);
   }
   if (!node)
     throw new Error('Unable to launch `node`, make sure it is in your PATH');


### PR DESCRIPTION
Turns out `which('node')` throws if there is no entry and we expect it to be falsy. This will break users whom's Node.js env gets set lazily.

Full stack without retries:

```
Error: not found: node
	at getNotFoundError (/Users/maxschmitt/Developer/playwright-vscode/node_modules/which/lib/index.js:16:17)
	at which2 (/Users/maxschmitt/Developer/playwright-vscode/node_modules/which/lib/index.js:76:9)
	at async findNode (/Users/maxschmitt/Developer/playwright-vscode/src/utils.ts:145:14)
	at async PlaywrightTest._runNode (/Users/maxschmitt/Developer/playwright-vscode/src/playwrightTest.ts:273:29)
	at async PlaywrightTest.getPlaywrightInfo (/Users/maxschmitt/Developer/playwright-vscode/src/playwrightTest.ts:69:23)
	at async Extension._rebuildModel (/Users/maxschmitt/Developer/playwright-vscode/src/extension.ts:244:30)
	at async Extension.activate (/Users/maxschmitt/Developer/playwright-vscode/out/extension.js:5816:5) {code: 'ENOENT', stack: 'Error: not found: node
	at getNotFoundError (…er/playwright-vscode/out/extension.js:5816:5)', message: 'not found: node'}
```

After: It retries