### PR TITLE
fix: detect remote vscode environments correctly

### DIFF
--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -334,9 +334,9 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
       return false;
     }
 
-    if (this._vscode.env.uiKind === this._vscode.UIKind.Web) {
+    if (this._vscode.env.remoteName) {
       this._vscode.window.showWarningMessage(
-          this._vscode.l10n.t('Show browser mode does not work in the Web mode')
+          this._vscode.l10n.t('Show browser mode does not work in remote vscode')
       );
       return false;
     }

--- a/src/traceViewer.ts
+++ b/src/traceViewer.ts
@@ -66,7 +66,7 @@ export class TraceViewer implements vscodeTypes.Disposable {
     if (this._traceViewerProcess)
       return;
     const allArgs = [config.cli, 'show-trace', `--stdin`];
-    if (this._vscode.env.uiKind === this._vscode.UIKind.Web) {
+    if (this._vscode.env.remoteName) {
       allArgs.push('--host', '0.0.0.0');
       allArgs.push('--port', '0');
     }

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -715,7 +715,8 @@ export class VSCode {
   window: any = {};
   workspace: any = {};
   env: any = {
-    uiKind: UIKind.Desktop
+    uiKind: UIKind.Desktop,
+    remoteName: undefined,
   };
   ProgressLocation = { Notification: 1 };
 


### PR DESCRIPTION
as per https://code.visualstudio.com/api/advanced-topics/remote-extensions

```ts
  // VS Code will return undefined for remoteName if working with a local workspace
  if (typeof vscode.env.remoteName === 'undefined') {
    vscode.window.showInformationMessage('Not currently connected to a remote workspace.');
  }
```