### PR TITLE
fix: show browser always in non-web mode

### DIFF
--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -334,7 +334,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
       return false;
     }
 
-    if (this._vscode.env.remoteName) {
+    if (this._vscode.env.uiKind === this._vscode.UIKind.Web) {
       this._vscode.window.showWarningMessage(
           this._vscode.l10n.t('Show browser mode does not work in remote vscode')
       );


### PR DESCRIPTION
Partial revert of https://github.com/microsoft/playwright-vscode/commit/d6881ef874f94f499a2be8f70e2d978e0babc847

For future reference:

![telegram-cloud-photo-size-2-5312353643384657502-y](https://github.com/microsoft/playwright-vscode/assets/17984549/5ce57b11-7ae6-44a1-a8ba-4260b61c8c31)

We keep the remoteName check in our trace viewer decision logic.

Fixes https://github.com/microsoft/playwright/issues/24254