### PR TITLE
fix: show browser when DISPLAY env var is provided

### DIFF
--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -334,7 +334,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
       return false;
     }
 
-    if (this._vscode.env.uiKind === this._vscode.UIKind.Web) {
+    if (this._vscode.env.uiKind === this._vscode.UIKind.Web && !process.env.DISPLAY) {
       this._vscode.window.showWarningMessage(
           this._vscode.l10n.t('Show browser mode does not work in remote vscode')
       );


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/26358

Tested with this: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/desktop-lite.md#desktop-lightweight-install-script

and that config:

```json
{
    "name": "Playwright jammy",
    "image": "mcr.microsoft.com/playwright:next-jammy",
    "remoteUser": "root",
    "runArgs": [
        "--privileged",
        "--init",
        "--shm-size=1g",
        "-v",
        "/var/run/docker.sock:/var/run/docker.sock"
    ],
    "features": {
        "desktop-lite": {
            "password": "vscode",
            "webPort": "6080",
            "vncPort": "5901"
        }
    }
}
```