### PR TITLE
French localization

### DIFF
--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -1,0 +1,16 @@
+{
+  "Pick locator": "Trouver locator",
+  "Record new": "Enregistrer nouveau",
+  "Record at cursor": "Enregistrer au niveau du curseur",
+  "Reveal test output": "Afficher les résultats des tests",
+  "Close all browsers": "Fermer tous les navigateurs",
+  "Accept to copy locator into clipboard": "Accepter pour copier le locator dans le presse-papiers",
+  "Can't record while running tests": "Impossible d'enregistrer pendant l'exécution des tests",
+  "this feature": "cette fonctionnalité",
+  "Playwright v1.25+ is required for {0} to work, v{1} found": "Playwright v1.25+ est requis pour que {0} fonctionne, v{1} trouvée",
+  "Show browser mode does not work in the Web mode": "Le mode affichage de navigateur ne peut être utilisé en mode Web",
+  "Can't close browsers while running tests": "Impossible de fermer les navigateurs pendant l'exécution des tests",
+  "No Playwright tests found.": "Aucun test Playwright trouvé.",
+  "Please install Playwright Test via running `npm i --save-dev @playwright/test`": "Veuillez installer Playwright Test en exécutant `npm i --save-dev @playwright/test`",
+  "Playwright Test v{0} or newer is required": "Playwright Test v{0} ou plus est nécessaire"
+}

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -1,0 +1,15 @@
+{
+  "description": "Exécutez des tests Playwright Test dans Visual Studio Code.",
+  "contributes.command.pw.extension.install": "Installer Playwright",
+  "contributes.command.pw.extension.installBrowsers": "Installer les navigateurs Playwright",
+  "contributes.command.pw.extension.command.inspect": "Trouver locator",
+  "contributes.command.pw.extension.command.closeBrowsers": "Fermer tous les navigateurs",
+  "contributes.command.pw.extension.command.recordNew": "Enregistrer nouveau",
+  "contributes.command.pw.extension.command.recordAtCursor": "Enregistrer au niveau du curseur",
+  "contributes.command.pw.extension.toggle.reuseBrowser": "Activer/désactiver la réutilisation du navigateur",
+  "contributes.command.pw.extension.toggle.showTrace": "Activer/désactiver Playwright Trace Viewer",
+  "configuration.playwright.env": "Variables d'environnement à transmettre à Playwright Test.",
+  "configuration.playwright.reuseBrowser": "Afficher et réutiliser le navigateur entre les tests.",
+  "configuration.playwright.showTrace": "Afficher les traces avec Trace Viewer.",
+  "views.test.pw.extension.settingsView": "Playwright"
+}


### PR DESCRIPTION
Translations for French

Language code is simply `fr`, as I believe it is standard French and there are no needs for region-specific language (belgium, swiss, french canada, ...)