### PR TITLE
chore: show more debug info when no Node.js is available

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,7 +249,7 @@ export class Extension {
               error instanceof NodeJSNotFoundError ? error.message : this._vscode.l10n.t('Please install Playwright Test via running `npm i --save-dev @playwright/test`')
           );
         }
-        console.error('[Playwright Test]:', (error as any)?.message, 1);
+        console.error('[Playwright Test]:', (error as any)?.message);
         continue;
       }
 

--- a/src/playwrightTest.ts
+++ b/src/playwrightTest.ts
@@ -63,34 +63,29 @@ export class PlaywrightTest {
     this._envProvider = envProvider;
   }
 
-  async getPlaywrightInfo(workspaceFolder: string, configFilePath: string): Promise<{ version: number, cli: string } | null> {
-    try {
-      const pwtInfo = await this._runNode([
-        '-e',
-        'try { const pwtIndex = require.resolve("@playwright/test"); const version = require("@playwright/test/package.json").version; console.log(JSON.stringify({ pwtIndex, version})); } catch { console.log("undefined"); }',
-      ], path.dirname(configFilePath));
-      const { version } = JSON.parse(pwtInfo);
-      const v = parseFloat(version.replace(/-(next|beta)$/, ''));
+  async getPlaywrightInfo(workspaceFolder: string, configFilePath: string): Promise<{ version: number, cli: string }> {
+    const pwtInfo = await this._runNode([
+      '-e',
+      'try { const pwtIndex = require.resolve("@playwright/test"); const version = require("@playwright/test/package.json").version; console.log(JSON.stringify({ pwtIndex, version})); } catch { console.log("undefined"); }',
+    ], path.dirname(configFilePath));
+    const { version } = JSON.parse(pwtInfo);
+    const v = parseFloat(version.replace(/-(next|beta)$/, ''));
 
-      // We only depend on playwright-core in 1.15+, bail out.
-      if (v < 1.19)
-        return { cli: '', version: v };
+    // We only depend on playwright-core in 1.15+, bail out.
+    if (v < 1.19)
+      return { cli: '', version: v };
 
-      const cliInfo = await this._runNode([
-        '-e',
-        'try { const cli = require.resolve("@playwright/test/cli"); console.log(JSON.stringify({ cli })); } catch { console.log("undefined"); }',
-      ], path.dirname(configFilePath));
-      let { cli } = JSON.parse(cliInfo);
+    const cliInfo = await this._runNode([
+      '-e',
+      'try { const cli = require.resolve("@playwright/test/cli"); console.log(JSON.stringify({ cli })); } catch { console.log("undefined"); }',
+    ], path.dirname(configFilePath));
+    let { cli } = JSON.parse(cliInfo);
 
-      // Dogfood for 'ttest'
-      if (cli.includes('/playwright/packages/playwright-test/') && configFilePath.includes('playwright-test'))
-        cli = path.join(workspaceFolder, 'tests/playwright-test/stable-test-runner/node_modules/@playwright/test/cli.js');
+    // Dogfood for 'ttest'
+    if (cli.includes('/playwright/packages/playwright-test/') && configFilePath.includes('playwright-test'))
+      cli = path.join(workspaceFolder, 'tests/playwright-test/stable-test-runner/node_modules/@playwright/test/cli.js');
 
-      return { cli, version: v };
-    } catch (e) {
-      console.error(e);
-    }
-    return null;
+    return { cli, version: v };
   }
 
   async listFiles(config: TestConfig): Promise<ConfigListFilesReport | null> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,6 +137,8 @@ export async function resolveSourceMap(file: string, fileToSources: Map<string, 
   return [file];
 }
 
+export class NodeJSNotFoundError extends Error {}
+
 let pathToNodeJS: string | undefined;
 
 export async function findNode(vscode: vscodeTypes.VSCode): Promise<string> {
@@ -154,7 +156,7 @@ export async function findNode(vscode: vscodeTypes.VSCode): Promise<string> {
   // This evaluates shell rc/profile files and makes nvm work.
   node ??= await findNodeViaShell(vscode);
   if (!node)
-    throw new Error('Unable to launch `node`, make sure it is in your PATH');
+    throw new NodeJSNotFoundError(`Unable to find 'node' executable.\nMake sure to have Node.js installed and available in your PATH.\nCurrent PATH: '${process.env.PATH}'.`);
   pathToNodeJS = node;
   return node;
 }


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/28703

Looks like that now in DevTools AND gets surfaced in VSCode as a warning.

<img width="449" alt="Screenshot 2024-01-10 at 11 00 40" src="https://github.com/microsoft/playwright-vscode/assets/17984549/c8e73245-0fb7-4d4f-9ac7-7fa7047b6a94">
