### PR TITLE
Fix findNodeViaShell to run within the workspace folder

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,9 +167,11 @@ async function findNodeViaShell(vscode: vscodeTypes.VSCode): Promise<string | un
   return new Promise<string | undefined>(resolve => {
     const startToken = '___START_PW_SHELL__';
     const endToken = '___END_PW_SHELL__';
+    const cwd = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined;
     const childProcess = spawn(`${vscode.env.shell} -i -c 'echo ${startToken} && which node && echo ${endToken}'`, {
       stdio: 'pipe',
-      shell: true
+      shell: true,
+      cwd,
     });
     let output = '';
     childProcess.stdout.on('data', data => output += data.toString());


### PR DESCRIPTION
This change sets the `cwd` option for `spawn()` to be the current workspace folder when spawning a shell in `findNodeViaShell`. Without this change, the search will run from within the current directory of the parent process, which is `/` by default. This PR makes it possible for project-local node version configurations to be used with the Playwright plugin.