### PR TITLE
chore: bump which dependency to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/parser": "^7.23.0",
         "@babel/traverse": "^7.23.2",
         "stack-utils": "^2.0.6",
-        "which": "^3.0.0",
+        "which": "^4.0.0",
         "ws": "^8.11.0"
       },
       "devDependencies": {
@@ -26,7 +26,7 @@
         "@types/node": "^18.11.9",
         "@types/stack-utils": "^2.0.1",
         "@types/vscode": "1.86.0",
-        "@types/which": "^2.0.1",
+        "@types/which": "^3.0.3",
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.44.0",
         "@typescript-eslint/parser": "^5.44.0",
@@ -830,9 +830,9 @@
       "dev": true
     },
     "node_modules/@types/which": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
-      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
+      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -3071,7 +3071,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/jackspeak": {
       "version": "2.0.3",
@@ -4378,17 +4379,25 @@
       "dev": true
     },
     "node_modules/which": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
-      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/which/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/word-wrap": {
@@ -5150,9 +5159,9 @@
       "dev": true
     },
     "@types/which": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
-      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
+      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==",
       "dev": true
     },
     "@types/ws": {
@@ -6652,7 +6661,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "jackspeak": {
       "version": "2.0.3",
@@ -7599,11 +7609,18 @@
       "dev": true
     },
     "which": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
-      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+          "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="
+        }
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@types/node": "^18.11.9",
     "@types/stack-utils": "^2.0.1",
     "@types/vscode": "1.86.0",
-    "@types/which": "^2.0.1",
+    "@types/which": "^3.0.3",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.44.0",
@@ -148,7 +148,7 @@
     "@babel/parser": "^7.23.0",
     "@babel/traverse": "^7.23.2",
     "stack-utils": "^2.0.6",
-    "which": "^3.0.0",
+    "which": "^4.0.0",
     "ws": "^8.11.0"
   }
 }


### PR DESCRIPTION
This internally was throwing this before (ignored via silent catch()):

```
Error: UNC host 'cpc-maxsc-heqga' access is not allowed
    at stat (C:\Users\maxschmitt\Developer\playwright-vscode\lib\fs.js:1597:10)
    at Object.stat (C:\Users\maxschmitt\Developer\playwright-vscode\lib\electron\js2c\node_init.js:2:4911)
    at isexe (c:\Users\maxschmitt\Developer\playwright-vscode\node_modules\isexe\windows.js:35:6)
    at isexe (c:\Users\maxschmitt\Developer\playwright-vscode\node_modules\isexe\index.js:34:3)
    at c:\Users\maxschmitt\Developer\playwright-vscode\node_modules\isexe\index.js:24:7
    at new Promise (<anonymous>)
    at isexe (c:\Users\maxschmitt\Developer\playwright-vscode\node_modules\isexe\index.js:23:12)
    at which2 (c:\Users\maxschmitt\Developer\playwright-vscode\node_modules\which\lib\index.js:63:24)
    at findNode (c:\Users\maxschmitt\Developer\playwright-vscode\src\utils.ts:153:12)
    at PlaywrightTest._runNode (c:\Users\maxschmitt\Developer\playwright-vscode\src\playwrightTest.ts:279:29)
    at PlaywrightTest._getPlaywrightInfoImpl (c:\Users\maxschmitt\Developer\playwright-vscode\src\playwrightTest.ts:76:21)
    at PlaywrightTest.getPlaywrightInfo (c:\Users\maxschmitt\Developer\playwright-vscode\src\playwrightTest.ts:71:14)
    at Extension._rebuildModel (c:\Users\maxschmitt\Developer\playwright-vscode\src\extension.ts:250:26)
    at Extension.activate (c:\Users\maxschmitt\Developer\playwright-vscode\src\extension.ts:208:5) {code: 'ERR_UNC_HOST_NOT_ALLOWED', stack: 'Error: UNC host 'cpc-maxsc-heqga' access is n…per\playwright-vscode\src\extension.ts:208:5)', message: 'UNC host 'cpc-maxsc-heqga' access is not allowed', toString: ƒ, Symbol(kIsNodeError): true}
```

Fixes https://github.com/microsoft/playwright/issues/29898