### PR TITLE
chore: set minimum Playwright version to v1.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This extension integrates Playwright into your VS Code workflow. Here is what it
 
 This extension works with [Playwright] version v1.38+ or newer.
 
-*If you are looking for the old extension that supported Playwright v1.14+, switch to e.g. v1.0.22 or v0.0.9 of this extension manually. Having said that, we highly recommend using the latest version of [Playwright]!*
 
 ## Install Playwright
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This extension integrates Playwright into your VS Code workflow. Here is what it
 
 ### Requirements
 
-This extension works with [Playwright] version v1.19+ or newer.
+This extension works with [Playwright] version v1.38+ or newer.
 
-*If you are looking for the old extension that supported Playwright v1.14+, switch to v0.0.9 of this extension manually. Having said that, we highly recommend using the latest version of [Playwright]!*
+*If you are looking for the old extension that supported Playwright v1.14+, switch to e.g. v1.0.22 or v0.0.9 of this extension manually. Having said that, we highly recommend using the latest version of [Playwright]!*
 
 ## Install Playwright
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -284,7 +284,7 @@ export class Extension implements RunHooks {
         continue;
       }
 
-      const minimumPlaywrightVersion = 1.28;
+      const minimumPlaywrightVersion = 1.38;
       if (playwrightInfo.version < minimumPlaywrightVersion) {
         if (userGesture) {
           this._vscode.window.showWarningMessage(


### PR DESCRIPTION
v1.38 is the minimum version which works as of today. This version got released on 14/09/2023.