### PR TITLE
test: assert test item tree order

### DIFF
--- a/tests/debug-tests.spec.ts
+++ b/tests/debug-tests.spec.ts
@@ -32,14 +32,14 @@ test('should debug all tests', async ({ activate }) => {
 
   const testRun = await vscode.testControllers[0].debug();
   expect(testRun.renderLog()).toBe(`
-    tests > test-2.spec.ts > should fail [2:0]
-      enqueued
-      started
-      failed
     tests > test-1.spec.ts > should pass [2:0]
       enqueued
       started
       passed
+    tests > test-2.spec.ts > should fail [2:0]
+      enqueued
+      started
+      failed
   `);
 
   await expect(vscode).toHaveExecLog(`

--- a/tests/list-tests.spec.ts
+++ b/tests/list-tests.spec.ts
@@ -668,8 +668,8 @@ test('should list parametrized tests', async ({ activate }) => {
     -   tests
       -   test.spec.ts
         -   one [3:0]
-        -   three [3:0]
         -   two [3:0]
+        -   three [3:0]
   `);
 });
 

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -226,7 +226,6 @@ class TestItem {
   innerToString(indent: string, result: string[]) {
     result.push(`${indent}- ${this.statusIcon()} ${this.treeTitle()}`);
     const items = [...this.children.map.values()];
-    items.sort((i1, i2) => itemOrder(i1).localeCompare(itemOrder(i2)));
     for (const item of items)
       item.innerToString(indent + '  ', result);
   }
@@ -264,14 +263,6 @@ class TestItem {
     }
     return `${titlePath.join(' > ')}${location}`;
   }
-}
-
-function itemOrder(item: TestItem) {
-  let result = '';
-  if (item.range)
-    result += item.range.start.line.toString().padStart(5, '0');
-  result += item.label;
-  return result;
 }
 
 class TestRunProfile {
@@ -426,7 +417,6 @@ export class TestRun {
     const indent = '  ';
     const result: string[] = [''];
     const tests = [...this.entries.keys()];
-    tests.sort((i1, i2) => itemOrder(i1).localeCompare(itemOrder(i2)));
     for (const test of tests) {
       const entries = this.entries.get(test)!;
       result.push(`  ${test.flatTitle()}`);
@@ -499,7 +489,6 @@ export class TestController {
   renderTestTree() {
     const result: string[] = [''];
     const items = [...this.items.map.values()];
-    items.sort((i1, i2) => itemOrder(i1).localeCompare(itemOrder(i2)));
     for (const item of items)
       item.innerToString('    ', result);
     result.push('  ');

--- a/tests/project-setup.spec.ts
+++ b/tests/project-setup.spec.ts
@@ -57,10 +57,10 @@ test.describe(() => {
     await expect(testController).toHaveTestTree(`
     -   setup.ts
       - ✅ setup [2:0]
-    -   teardown.ts
-      - ✅ teardown [2:0]
     -   test.ts
       - ✅ test [2:0]
+    -   teardown.ts
+      - ✅ teardown [2:0]
   `);
 
     const output = testRun.renderLog({ output: true });
@@ -82,10 +82,10 @@ test.describe(() => {
     const testRun = await testController.run();
 
     await expect(testController).toHaveTestTree(`
-    -   teardown.ts
-      - ✅ teardown [2:0]
     -   test.ts
       - ✅ test [2:0]
+    -   teardown.ts
+      - ✅ teardown [2:0]
   `);
 
     const output = testRun.renderLog({ output: true });
@@ -121,9 +121,9 @@ test.describe(() => {
     await expect(testController).toHaveTestTree(`
     -   setup.ts
       - ✅ setup [2:0]
+    -   test.ts
     -   teardown.ts
       - ✅ teardown [2:0]
-    -   test.ts
   `);
   });
 });
@@ -139,9 +139,9 @@ test('should run setup and teardown for test', async ({ activate }) => {
   await expect(testController).toHaveTestTree(`
     -   setup.ts
       - ✅ setup [2:0]
-    -   teardown.ts
-      - ✅ teardown [2:0]
     -   test.ts
       - ✅ test [2:0]
+    -   teardown.ts
+      - ✅ teardown [2:0]
   `);
 });

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -43,14 +43,14 @@ test('should run all tests', async ({ activate }) => {
   `);
 
   expect(testRun.renderLog()).toBe(`
-    tests > test-2.spec.ts > should fail [2:0]
-      enqueued
-      started
-      failed
     tests > test-1.spec.ts > should pass [2:0]
       enqueued
       started
       passed
+    tests > test-2.spec.ts > should fail [2:0]
+      enqueued
+      started
+      failed
   `);
 
   await expect(vscode).toHaveExecLog(`
@@ -682,12 +682,12 @@ test('should run all parametrized tests', async ({ activate }) => {
       enqueued
       started
       passed
-    tests > test.spec.ts > test-three [3:0]
+    tests > test.spec.ts > test-two [3:0]
       enqueued
       enqueued
       started
       passed
-    tests > test.spec.ts > test-two [3:0]
+    tests > test.spec.ts > test-three [3:0]
       enqueued
       enqueued
       started

--- a/tests/source-map.spec.ts
+++ b/tests/source-map.spec.ts
@@ -225,9 +225,9 @@ test('should discover new tests', async ({ activate }) => {
   await expect(testController).toHaveTestTree(`
     -   tests
       -   test.spec.ts
-        -   new [2:0]
         -   one [3:0]
         -   two [4:0]
+        -   new [2:0]
   `);
 
   await expect(vscode).toHaveExecLog(`


### PR DESCRIPTION
We should not sort in our VSCode mock's, since thats also not something VSCode is doing.

Test for https://github.com/microsoft/playwright/issues/30936.

Requires a more recent test-runner roll.

Closes https://github.com/microsoft/playwright-vscode/pull/489