### PR TITLE
chore: remove pw.extension.install from 'activation events'

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "Testing"
   ],
   "activationEvents": [
-    "workspaceContains:**/*playwright*.config.{ts,js,mjs}",
-    "onCommand:pw.extension.install"
+    "workspaceContains:**/*playwright*.config.{ts,js,mjs}"
   ],
   "main": "./out/extension.js",
   "l10n": "./l10n",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "ms-playwright",
   "repository": "https://github.com/microsoft/playwright-vscode",
   "bugs": {
-    "url": "https://github.com/microsoft/playwright-vscode/issues"
+    "url": "https://github.com/microsoft/playwright/issues"
   },
   "engines": {
     "vscode": "^1.86.0"


### PR DESCRIPTION
As per:

<img width="1254" alt="Screenshot 2024-05-28 at 14 50 31" src="https://github.com/microsoft/playwright-vscode/assets/17984549/65b27652-83f9-4fa2-ab80-8a21096e1cac">

We get this since a while. We updated our minimum VSCode version to a recent one, so we should be save to remove that.