### PR TITLE
fix: continue to support reporter v1 interface

### DIFF
--- a/src/oopReporter.ts
+++ b/src/oopReporter.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { TeleReporterEmitter } from './upstream/teleEmitter';
+import { TeleReporterEmitterV1 } from './upstream/teleEmitterV1';
+import { TeleReporterEmitterV2 } from './upstream/teleEmitterV2';
 import { WebSocketTransport } from './transport';
 import { FullResult } from './upstream/reporter';
+
+const TeleReporterEmitter = process.env.PW_TEST_REPORTER_USE_V1_REPORTER ? TeleReporterEmitterV1 : TeleReporterEmitterV2;
 
 class TeleReporter extends TeleReporterEmitter {
   private _hasSender: boolean;

--- a/src/playwrightTestCLI.ts
+++ b/src/playwrightTestCLI.ts
@@ -100,7 +100,7 @@ export class PlaywrightTestCLI {
 
     // Playwright will restart itself as child process in the ESM mode and won't inherit the 3/4 pipes.
     // Always use ws transport to mitigate it.
-    const reporterServer = new ReporterServer(this._vscode);
+    const reporterServer = new ReporterServer(this._vscode, this._model.config.version);
     const node = await findNode(this._vscode, this._model.config.workspaceFolder);
     const configFolder = path.dirname(this._model.config.configFile);
     const configFile = path.basename(this._model.config.configFile);
@@ -172,7 +172,7 @@ export class PlaywrightTestCLI {
       this._log(`${escapeRegex(path.relative(this._model.config.workspaceFolder, configFolder))}> debug -c ${configFile}${relativeLocations.length ? ' ' + relativeLocations.join(' ') : ''}`);
     }
 
-    const reporterServer = new ReporterServer(this._vscode);
+    const reporterServer = new ReporterServer(this._vscode, this._model.config.version);
     const testOptions = await this._options.runHooks.onWillRunTests(this._model.config, true);
     try {
       await this._vscode.debug.startDebugging(undefined, {

--- a/src/reporterServer.ts
+++ b/src/reporterServer.ts
@@ -28,9 +28,11 @@ export class ReporterServer {
   private _clientSocketCallback!: (socket: WebSocket) => void;
   private _wsServer: WebSocketServer | undefined;
   private _vscode: vscodeTypes.VSCode;
+  private _playwrightVersion: number;
 
-  constructor(vscode: vscodeTypes.VSCode) {
+  constructor(vscode: vscodeTypes.VSCode, playwrightVersion: number) {
     this._vscode = vscode;
+    this._playwrightVersion = playwrightVersion;
     this._clientSocketPromise = new Promise(f => this._clientSocketCallback = f);
   }
 
@@ -39,6 +41,7 @@ export class ReporterServer {
     return {
       PW_TEST_REPORTER: require.resolve('./oopReporter'),
       PW_TEST_REPORTER_WS_ENDPOINT: wsEndpoint,
+      ...(this._playwrightVersion < 1.36 ? { PW_TEST_REPORTER_USE_V1_REPORTER: '1' } : {})
     };
   }
 

--- a/src/upstream/teleEmitterV1.ts
+++ b/src/upstream/teleEmitterV1.ts
@@ -1,0 +1,275 @@
+// *************** DO NOT EDIT *******************
+// THIS FILE HAS BEEN COPIED FROM PLAYWRIGHT REPO
+// ***********************************************
+
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'path';
+import { createGuid } from '../utils';
+import type * as reporterTypes from './reporter';
+import type * as teleReceiver from './teleReceiver';
+import { serializeRegexPatterns } from './teleReceiver';
+import type { Reporter } from './reporter';
+
+export type TeleReporterEmitterOptions = {
+  omitOutput?: boolean;
+  omitBuffers?: boolean;
+};
+
+export class TeleReporterEmitterV1 implements Reporter {
+  private _messageSink: (message: teleReceiver.JsonEvent) => void;
+  private _rootDir!: string;
+  private _emitterOptions: TeleReporterEmitterOptions;
+
+  constructor(messageSink: (message: teleReceiver.JsonEvent) => void, options: TeleReporterEmitterOptions = {}) {
+    this._messageSink = messageSink;
+    this._emitterOptions = options;
+  }
+
+  onBegin(config: reporterTypes.FullConfig, suite: reporterTypes.Suite) {
+    this._rootDir = config.rootDir;
+    this._messageSink({ method: 'onConfigure', params: { config: this._serializeConfig(config) } });
+    const projects = suite.suites.map(projectSuite => this._serializeProject(projectSuite));
+    for (const project of projects)
+      this._messageSink({ method: 'onProject', params: { project } });
+    this._messageSink({ method: 'onBegin', params: undefined });
+  }
+
+  onTestBegin(test: reporterTypes.TestCase, result: reporterTypes.TestResult): void {
+    (result as any)[idSymbol] = createGuid();
+    this._messageSink({
+      method: 'onTestBegin',
+      params: {
+        testId: test.id,
+        result: this._serializeResultStart(result)
+      }
+    });
+  }
+
+  onTestEnd(test: reporterTypes.TestCase, result: reporterTypes.TestResult): void {
+    const testEnd: teleReceiver.JsonTestEnd = {
+      testId: test.id,
+      expectedStatus: test.expectedStatus,
+      annotations: test.annotations,
+      timeout: test.timeout,
+    };
+    this._messageSink({
+      method: 'onTestEnd',
+      params: {
+        test: testEnd,
+        result: this._serializeResultEnd(result),
+      }
+    });
+  }
+
+  onStepBegin(test: reporterTypes.TestCase, result: reporterTypes.TestResult, step: reporterTypes.TestStep): void {
+    (step as any)[idSymbol] = createGuid();
+    this._messageSink({
+      method: 'onStepBegin',
+      params: {
+        testId: test.id,
+        resultId: (result as any)[idSymbol],
+        step: this._serializeStepStart(step)
+      }
+    });
+  }
+
+  onStepEnd(test: reporterTypes.TestCase, result: reporterTypes.TestResult, step: reporterTypes.TestStep): void {
+    this._messageSink({
+      method: 'onStepEnd',
+      params: {
+        testId: test.id,
+        resultId: (result as any)[idSymbol],
+        step: this._serializeStepEnd(step)
+      }
+    });
+  }
+
+  onError(error: reporterTypes.TestError): void {
+    this._messageSink({
+      method: 'onError',
+      params: { error }
+    });
+  }
+
+  onStdOut(chunk: string | Buffer, test?: reporterTypes.TestCase, result?: reporterTypes.TestResult): void {
+    this._onStdIO('stdout', chunk, test, result);
+  }
+
+  onStdErr(chunk: string | Buffer, test?: reporterTypes.TestCase, result?: reporterTypes.TestResult): void {
+    this._onStdIO('stderr', chunk, test, result);
+  }
+
+  private _onStdIO(type: teleReceiver.JsonStdIOType, chunk: string | Buffer, test: void | reporterTypes.TestCase, result: void | reporterTypes.TestResult): void {
+    if (this._emitterOptions.omitOutput)
+      return;
+    const isBase64 = typeof chunk !== 'string';
+    const data = isBase64 ? chunk.toString('base64') : chunk;
+    this._messageSink({
+      method: 'onStdIO',
+      params: { testId: test?.id, resultId: result ? (result as any)[idSymbol] : undefined, type, data, isBase64 }
+    });
+  }
+
+  async onEnd(result: reporterTypes.FullResult) {
+    const resultPayload: teleReceiver.JsonFullResult = {
+      status: result.status,
+      startTime: Date.now(),
+      duration: 0,
+    };
+    this._messageSink({
+      method: 'onEnd',
+      params: {
+        result: resultPayload
+      }
+    });
+  }
+
+  async onExit() {
+  }
+
+  printsToStdio() {
+    return false;
+  }
+
+  private _serializeConfig(config: reporterTypes.FullConfig): teleReceiver.JsonConfig {
+    return {
+      configFile: this._relativePath(config.configFile),
+      globalTimeout: config.globalTimeout,
+      maxFailures: config.maxFailures,
+      metadata: config.metadata,
+      rootDir: config.rootDir,
+      version: config.version,
+      workers: config.workers,
+    };
+  }
+
+  private _serializeProject(suite: reporterTypes.Suite): teleReceiver.JsonProject {
+    const project = suite.project()!;
+    const report: teleReceiver.JsonProject = {
+      metadata: project.metadata,
+      name: project.name,
+      outputDir: this._relativePath(project.outputDir),
+      repeatEach: project.repeatEach,
+      retries: project.retries,
+      testDir: this._relativePath(project.testDir),
+      testIgnore: serializeRegexPatterns(project.testIgnore),
+      testMatch: serializeRegexPatterns(project.testMatch),
+      timeout: project.timeout,
+      suites: suite.suites.map(fileSuite => {
+        return this._serializeSuite(fileSuite);
+      }),
+      grep: serializeRegexPatterns(project.grep),
+      grepInvert: serializeRegexPatterns(project.grepInvert || []),
+      dependencies: project.dependencies,
+      snapshotDir: this._relativePath(project.snapshotDir),
+      teardown: project.teardown,
+    };
+    return report;
+  }
+
+  private _serializeSuite(suite: reporterTypes.Suite): teleReceiver.JsonSuite {
+    const result = {
+      title: suite.title,
+      location: this._relativeLocation(suite.location),
+      suites: suite.suites.map(s => this._serializeSuite(s)),
+      tests: suite.tests.map(t => this._serializeTest(t)),
+    };
+    return result;
+  }
+
+  private _serializeTest(test: reporterTypes.TestCase): teleReceiver.JsonTestCase {
+    return {
+      testId: test.id,
+      title: test.title,
+      location: this._relativeLocation(test.location),
+      retries: test.retries,
+      tags: test.tags,
+      repeatEachIndex: test.repeatEachIndex,
+    };
+  }
+
+  private _serializeResultStart(result: reporterTypes.TestResult): teleReceiver.JsonTestResultStart {
+    return {
+      id: (result as any)[idSymbol],
+      retry: result.retry,
+      workerIndex: result.workerIndex,
+      parallelIndex: result.parallelIndex,
+      startTime: +result.startTime,
+    };
+  }
+
+  private _serializeResultEnd(result: reporterTypes.TestResult): teleReceiver.JsonTestResultEnd {
+    return {
+      id: (result as any)[idSymbol],
+      duration: result.duration,
+      status: result.status,
+      errors: result.errors,
+      attachments: this._serializeAttachments(result.attachments),
+    };
+  }
+
+  _serializeAttachments(attachments: reporterTypes.TestResult['attachments']): teleReceiver.JsonAttachment[] {
+    return attachments.map(a => {
+      return {
+        ...a,
+        // There is no Buffer in the browser, so there is no point in sending the data there.
+        base64: (a.body && !this._emitterOptions.omitBuffers) ? a.body.toString('base64') : undefined,
+      };
+    });
+  }
+
+  private _serializeStepStart(step: reporterTypes.TestStep): teleReceiver.JsonTestStepStart {
+    return {
+      id: (step as any)[idSymbol],
+      parentStepId: (step.parent as any)?.[idSymbol],
+      title: step.title,
+      category: step.category,
+      startTime: +step.startTime,
+      location: this._relativeLocation(step.location),
+    };
+  }
+
+  private _serializeStepEnd(step: reporterTypes.TestStep): teleReceiver.JsonTestStepEnd {
+    return {
+      id: (step as any)[idSymbol],
+      duration: step.duration,
+      error: step.error,
+    };
+  }
+
+  private _relativeLocation(location: reporterTypes.Location): reporterTypes.Location;
+  private _relativeLocation(location?: reporterTypes.Location): reporterTypes.Location | undefined;
+  private _relativeLocation(location: reporterTypes.Location | undefined): reporterTypes.Location | undefined {
+    if (!location)
+      return location;
+    return {
+      ...location,
+      file: this._relativePath(location.file),
+    };
+  }
+
+  private _relativePath(absolutePath: string): string;
+  private _relativePath(absolutePath?: string): string | undefined;
+  private _relativePath(absolutePath?: string): string | undefined {
+    if (!absolutePath)
+      return absolutePath;
+    return path.relative(this._rootDir, absolutePath);
+  }
+}
+
+const idSymbol = Symbol('id');

--- a/src/upstream/teleEmitterV2.ts
+++ b/src/upstream/teleEmitterV2.ts
@@ -30,7 +30,7 @@ export type TeleReporterEmitterOptions = {
   omitBuffers?: boolean;
 };
 
-export class TeleReporterEmitter implements ReporterV2 {
+export class TeleReporterEmitterV2 implements ReporterV2 {
   private _messageSink: (message: teleReceiver.JsonEvent) => void;
   private _rootDir!: string;
   private _emitterOptions: TeleReporterEmitterOptions;
@@ -135,8 +135,8 @@ export class TeleReporterEmitter implements ReporterV2 {
   async onEnd(result: reporterTypes.FullResult) {
     const resultPayload: teleReceiver.JsonFullResult = {
       status: result.status,
-      startTime: result.startTime.getTime(),
-      duration: result.duration,
+      startTime: result.startTime?.getTime() ?? Date.now(),
+      duration: result.duration ?? 0,
     };
     this._messageSink({
       method: 'onEnd',

--- a/tests-integration/playwright.config.ts
+++ b/tests-integration/playwright.config.ts
@@ -16,7 +16,7 @@
 import { defineConfig } from '@playwright/test';
 import { TestOptions } from './tests/baseTest';
 
-export default defineConfig<void, TestOptions>({
+export default defineConfig<TestOptions>({
   reporter: process.env.CI ? 'html' : 'list',
   timeout: 120_000,
   workers: 1,
@@ -24,12 +24,11 @@ export default defineConfig<void, TestOptions>({
     timeout: 30_000,
   },
   globalSetup: './globalSetup',
-  projects: [
-    {
-      name: 'VSCode insiders',
-      use: {
-        vscodeVersion: 'insiders',
-      }
+  projects: ['next', 'latest', '1.33', '1.35', '1.38', '1.40', '1.42'].map(playwrightVersion => ({
+    name: 'VSCode insiders / Playwright @latest',
+    use: {
+      vscodeVersion: 'insiders',
+      playwrightVersion,
     }
-  ]
+  })),
 });

--- a/tests-integration/tests/baseTest.ts
+++ b/tests-integration/tests/baseTest.ts
@@ -23,6 +23,7 @@ import { spawnSync } from 'child_process';
 
 export type TestOptions = {
   vscodeVersion: string;
+  playwrightVersion: string;
 };
 
 type TestFixtures = TestOptions & {
@@ -33,6 +34,7 @@ type TestFixtures = TestOptions & {
 
 export const test = base.extend<TestFixtures>({
   vscodeVersion: ['insiders', { option: true }],
+  playwrightVersion: ['latest', { option: true }],
   workbox: async ({ vscodeVersion, createProject, createTempDir }, use) => {
     const defaultCachePath = await createTempDir();
     const vscodePath = await downloadAndUnzipVSCode(vscodeVersion);
@@ -68,7 +70,7 @@ export const test = base.extend<TestFixtures>({
       await fs.promises.cp(logPath, logOutputPath, { recursive: true });
     }
   },
-  createProject: async ({ createTempDir }, use) => {
+  createProject: async ({ createTempDir, playwrightVersion }, use) => {
     await use(async () => {
       // We want to be outside of the project directory to avoid already installed dependencies.
       const projectPath = await createTempDir();
@@ -77,6 +79,16 @@ export const test = base.extend<TestFixtures>({
       console.log(`Creating project in ${projectPath}`);
       await fs.promises.mkdir(projectPath);
       spawnSync(`npm init playwright@latest --yes -- --quiet --browser=chromium --gha --install-deps`, {
+        cwd: projectPath,
+        stdio: 'inherit',
+        shell: true,
+      });
+      spawnSync(`npm install -D @playwright/test@${playwrightVersion}`, {
+        cwd: projectPath,
+        stdio: 'inherit',
+        shell: true,
+      });
+      spawnSync(`npx playwright install chromium`, {
         cwd: projectPath,
         stdio: 'inherit',
         shell: true,


### PR DESCRIPTION
Playwright [v1.36 introduced](https://github.com/microsoft/playwright/commit/86c1abd934f98fb892bab2898ac6ac723f6b4b62) the reporter protocol v2, Playwright v1.38 introduced `FullResult.{startTime/duration}`.

This change will use reporter v1 interface for pre 1.36 makes the v2 TeleEmitter implementation for an optional startTime/duration.