### PR TITLE
feat(trace-viewer): refactor trace viewer

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -759,6 +759,10 @@ export class Extension implements RunHooks {
     this._treeItemSelected(testItem);
   }
 
+  traceViewerInfoForTest() {
+    return this._traceViewer()?.infoForTest();
+  }
+
   private _showTrace(testItem: vscodeTypes.TestItem) {
     const traceUrl = (testItem as any)[traceUrlSymbol];
     if (traceUrl)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,13 +235,6 @@ export class Extension implements RunHooks {
       this._reusedBrowser,
       this._diagnostics,
       this._treeItemObserver,
-      this._models.onUpdated(() => {
-        const selectedModel = this._models.selectedModel();
-        for (const model of this._models.models()) {
-          if (model !== selectedModel)
-            model.traceViewer()?.close();
-        }
-      }),
       registerTerminalLinkProvider(this._vscode),
     ];
     const fileSystemWatchers = [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,7 +67,7 @@ export class Extension implements RunHooks {
   private _debugHighlight: DebugHighlight;
   private _isUnderTest: boolean;
   private _reusedBrowser: ReusedBrowser;
-  private _traceViewer: TraceViewer;
+  private _currentTraceViewer?: TraceViewer;
   private _settingsModel: SettingsModel;
   private _settingsView!: SettingsView;
   private _diagnostics: vscodeTypes.DiagnosticCollection;
@@ -112,7 +112,6 @@ export class Extension implements RunHooks {
       onStdOut: this._debugHighlight.onStdOut.bind(this._debugHighlight),
       requestWatchRun: this._runWatchedTests.bind(this),
     });
-    this._traceViewer = new TraceViewer(this._vscode, this._settingsModel, this._envProvider.bind(this));
     this._testController = vscode.tests.createTestController('playwright', 'Playwright');
     this._testController.resolveHandler = item => this._resolveChildren(item);
     this._testController.refreshHandler = () => this._rebuildModels(true).then(() => {});
@@ -486,7 +485,7 @@ export class Extension implements RunHooks {
         // if trace viewer is currently displaying the trace file about to be replaced, it needs to be refreshed
         const prevTrace = (testItem as any)[traceUrlSymbol];
         (testItem as any)[traceUrlSymbol] = trace;
-        if (enqueuedSingleTest || prevTrace === this._traceViewer.currentFile())
+        if (enqueuedSingleTest || prevTrace === this._currentTraceViewer?.currentFile())
           this._showTrace(testItem);
 
         if (result.status === test.expectedStatus) {
@@ -538,7 +537,7 @@ export class Extension implements RunHooks {
     if (isDebug) {
       await model.debugTests(items, testListener, testRun.token);
     } else {
-      await this._traceViewer.willRunTests(model.config);
+      await this._enabledTraceView()?.willRunTests();
       await model.runTests(items, testListener, testRun.token);
     }
   }
@@ -757,18 +756,25 @@ export class Extension implements RunHooks {
 
   private _showTrace(testItem: vscodeTypes.TestItem) {
     const traceUrl = (testItem as any)[traceUrlSymbol];
-    const testModel = this._models.selectedModel();
-    if (testModel)
-      this._traceViewer.open(traceUrl, testModel.config);
+    if (traceUrl)
+      this._enabledTraceView()?.open(traceUrl);
   }
 
   private _treeItemSelected(treeItem: vscodeTypes.TreeItem | null) {
     if (!treeItem)
       return;
     const traceUrl = (treeItem as any)[traceUrlSymbol] || '';
-    const testModel = this._models.selectedModel();
-    if (testModel)
-      this._traceViewer.open(traceUrl, testModel.config);
+    if (!traceUrl && !this._currentTraceViewer?.isStarted())
+      return;
+    this._enabledTraceView()?.open(traceUrl);
+  }
+
+  private _enabledTraceView() {
+    const traceViewer = this._models.selectedModel()?.enabledTraceViewer();
+    if (traceViewer !== this._currentTraceViewer)
+      this._currentTraceViewer?.close();
+    this._currentTraceViewer = traceViewer;
+    return traceViewer;
   }
 
   private _queueCommand<T>(callback: () => Promise<T>, defaultValue: T): Promise<T> {

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -30,6 +30,7 @@ import type { PlaywrightTestRunOptions, RunHooks, TestConfig } from './playwrigh
 import { PlaywrightTestCLI } from './playwrightTestCLI';
 import { upstreamTreeItem } from './testTree';
 import { collectTestIds } from './upstream/testTree';
+import { SpawnTraceViewer } from './traceViewer';
 
 export type TestEntry = reporterTypes.TestCase | reporterTypes.Suite;
 
@@ -79,6 +80,7 @@ export class TestModel extends DisposableBase {
   private _startedDevServer = false;
   private _useLegacyCLIDriver: boolean;
   private _collection: TestModelCollection;
+  private _spawnTraceViewer: SpawnTraceViewer;
 
   constructor(collection: TestModelCollection, workspaceFolder: string, configFile: string, playwrightInfo: { cli: string, version: number }) {
     super();
@@ -89,6 +91,22 @@ export class TestModel extends DisposableBase {
     this._useLegacyCLIDriver = playwrightInfo.version < 1.44;
     this._playwrightTest =  this._useLegacyCLIDriver ? new PlaywrightTestCLI(this._vscode, this, collection.embedder) : new PlaywrightTestServer(this._vscode, this, collection.embedder);
     this.tag = new this._vscode.TestTag(this.config.configFile);
+    this._spawnTraceViewer = new SpawnTraceViewer(this._vscode, this._embedder.envProvider, this.config);
+
+    this._disposables.push(
+        this._spawnTraceViewer,
+        this._embedder.settingsModel.showTrace.onChange(value => {
+          if (!value)
+            this._spawnTraceViewer.close();
+        }),
+    );
+  }
+
+  enabledTraceViewer() {
+    if (!this._embedder.settingsModel.showTrace.get())
+      return;
+    if (this._spawnTraceViewer.checkVersion())
+      return this._spawnTraceViewer;
   }
 
   async _loadModelIfNeeded(configSettings: ConfigSettings | undefined) {
@@ -127,6 +145,7 @@ export class TestModel extends DisposableBase {
     this._playwrightTest.reset();
     this._watches.clear();
     this._ranGlobalSetup = false;
+    this._spawnTraceViewer.close();
   }
 
   projects(): TestProject[] {

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -102,7 +102,7 @@ export class TestModel extends DisposableBase {
     );
   }
 
-  enabledTraceViewer() {
+  traceViewer() {
     if (!this._embedder.settingsModel.showTrace.get())
       return;
     if (this._spawnTraceViewer.checkVersion())

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -667,6 +667,15 @@ export class TestModelCollection extends DisposableBase {
     this.embedder = embedder;
     this._didUpdate = new vscode.EventEmitter();
     this.onUpdated = this._didUpdate.event;
+    this._disposables.push(
+        this.onUpdated(() => {
+          const selectedModel = this.selectedModel();
+          for (const model of this.models()) {
+            if (model !== selectedModel)
+              model.traceViewer()?.close();
+          }
+        })
+    );
   }
 
   setModelEnabled(configFile: string, enabled: boolean, userGesture?: boolean) {

--- a/src/traceViewer.ts
+++ b/src/traceViewer.ts
@@ -27,7 +27,7 @@ export class SpawnTraceViewer {
   private _traceViewerProcess: ChildProcess | undefined;
   private _currentFile?: string;
   private _config: TestConfig;
-  private _serverUrlPrefix?: string;
+  private _serverUrlPrefixForTest?: string;
 
   constructor(vscode: vscodeTypes.VSCode, envProvider: () => NodeJS.ProcessEnv, config: TestConfig) {
     this._vscode = vscode;
@@ -87,7 +87,7 @@ export class SpawnTraceViewer {
       traceViewerProcess.stdout?.on('data', data => {
         const match = data.toString().match(/Listening on (.*)/);
         if (match)
-          this._serverUrlPrefix = match[1];
+          this._serverUrlPrefixForTest = match[1];
       });
     }
   }
@@ -108,7 +108,7 @@ export class SpawnTraceViewer {
     this._traceViewerProcess?.stdin?.end();
     this._traceViewerProcess = undefined;
     this._currentFile = undefined;
-    this._serverUrlPrefix = undefined;
+    this._serverUrlPrefixForTest = undefined;
   }
 
   dispose() {
@@ -116,11 +116,11 @@ export class SpawnTraceViewer {
   }
 
   infoForTest() {
-    if (!this._serverUrlPrefix)
+    if (!this._serverUrlPrefixForTest)
       return;
     return {
       type: 'spawn',
-      serverUrlPrefix: this._serverUrlPrefix,
+      serverUrlPrefix: this._serverUrlPrefixForTest,
       testConfigFile: this._config.configFile,
       traceFile: this.currentFile(),
     };

--- a/src/traceViewer.ts
+++ b/src/traceViewer.ts
@@ -111,10 +111,6 @@ export class SpawnTraceViewer {
     this._serverUrlPrefixForTest = undefined;
   }
 
-  dispose() {
-    this.close();
-  }
-
   infoForTest() {
     if (!this._serverUrlPrefixForTest)
       return;

--- a/src/vscodeTypes.ts
+++ b/src/vscodeTypes.ts
@@ -57,4 +57,6 @@ export type {
   TerminalLink,
 } from 'vscode';
 
-export type VSCode = typeof import('vscode');
+export type VSCode = typeof import('vscode') & {
+  isUnderTest?: boolean;
+};

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -498,6 +498,7 @@ export class TestController {
   private _didCreateTestRun = new EventEmitter<TestRun>();
   readonly onDidCreateTestRun = this._didCreateTestRun.event;
 
+  refreshHandler: (item: TestItem | null) => Promise<void>;
   resolveHandler: (item: TestItem | null) => Promise<void>;
 
   constructor(readonly vscode: VSCode, id: string, label: string) {

--- a/tests/spawn-trace-viewer.spec.ts
+++ b/tests/spawn-trace-viewer.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { enableConfigs, expect, selectConfig, selectTestItem, test, traceViewerInfo } from './utils';
+
+test.beforeEach(({ showBrowser }) => {
+  test.skip(showBrowser);
+  // prevents spawn trace viewer process from opening in browser
+  process.env.PWTEST_UNDER_TEST = '1';
+});
+
+test.use({ showTrace: true, envRemoteName: 'ssh-remote' });
+
+test('@smoke should open trace viewer', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.run();
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    type: 'spawn',
+    traceFile: expect.stringContaining('pass'),
+  });
+});
+
+test('should change opened file in trace viewer', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+      test('two', async () => {});
+    `,
+  });
+
+  await testController.run();
+  await testController.expandTestItems(/test.spec/);
+
+  selectTestItem(testController.findTestItems(/one/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    type: 'spawn',
+    traceFile: expect.stringContaining('one'),
+  });
+
+  selectTestItem(testController.findTestItems(/two/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    type: 'spawn',
+    traceFile: expect.stringContaining('two'),
+  });
+});
+
+test('should not open trace viewer if test did not run', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toBeUndefined();
+});
+
+test('should refresh trace viewer while test is running', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => await new Promise(r => setTimeout(r, 1000)));
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  await Promise.all([
+    testController.run(),
+    expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+      type: 'spawn',
+      traceFile: expect.stringMatching(/\.json$/),
+    }),
+  ]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    type: 'spawn',
+    traceFile: expect.stringMatching(/\.zip$/),
+  });
+});
+
+test('should close trace viewer if test configs refreshed', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  await testController.run();
+  await testController.expandTestItems(/test.spec/);
+  selectTestItem(testController.findTestItems(/pass/)[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    type: 'spawn',
+    traceFile: expect.stringContaining('pass'),
+  });
+
+  await testController.refreshHandler(null);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toBeUndefined();
+});
+
+test('should open new trace viewer when another test config is selected', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright1.config.js': `module.exports = { testDir: 'tests1' }`,
+    'playwright2.config.js': `module.exports = { testDir: 'tests2' }`,
+    'tests1/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+      `,
+    'tests2/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+      `,
+  });
+
+  await enableConfigs(vscode, ['playwright1.config.js', 'playwright2.config.js']);
+  await selectConfig(vscode, 'playwright1.config.js');
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/one/);
+  await testController.run(testItems);
+
+  selectTestItem(testItems[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    type: 'spawn',
+    serverUrlPrefix: expect.stringContaining('http'),
+    testConfigFile: expect.stringContaining('playwright1.config.js'),
+  });
+  const serverUrlPrefix1 = traceViewerInfo(vscode);
+
+  // closes opened trace viewer
+  await selectConfig(vscode, 'playwright2.config.js');
+
+  await expect.poll(() => traceViewerInfo(vscode)).toBeUndefined();
+
+  // opens trace viewer from selected test config
+  selectTestItem(testItems[0]);
+
+  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
+    type: 'spawn',
+    serverUrlPrefix: expect.stringContaining('http'),
+    testConfigFile: expect.stringContaining('playwright2.config.js'),
+  });
+  const serverUrlPrefix2 = traceViewerInfo(vscode);
+
+  expect(serverUrlPrefix2).not.toBe(serverUrlPrefix1);
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -29,6 +29,8 @@ type ActivateResult = {
 type TestFixtures = {
   vscode: VSCode,
   activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any> }) => Promise<ActivateResult>;
+  showTrace: boolean;
+  envRemoteName?: string;
 };
 
 export type WorkerOptions = {
@@ -114,12 +116,14 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions>({
   overridePlaywrightVersion: [undefined, { option: true, scope: 'worker' }],
   showBrowser: [false, { option: true, scope: 'worker' }],
   vsCodeVersion: [1.86, { option: true, scope: 'worker' }],
+  showTrace: false,
+  envRemoteName: undefined,
 
   vscode: async ({ browser, vsCodeVersion }, use) => {
     await use(new VSCode(vsCodeVersion, path.resolve(__dirname, '..'), browser));
   },
 
-  activate: async ({ vscode, showBrowser, overridePlaywrightVersion }, use, testInfo) => {
+  activate: async ({ vscode, showBrowser, showTrace, envRemoteName, overridePlaywrightVersion }, use, testInfo) => {
     const instances: VSCode[] = [];
     await use(async (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any> }) => {
       if (options?.workspaceFolders) {
@@ -134,6 +138,10 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions>({
         configuration.update('env', options.env);
       if (showBrowser)
         configuration.update('reuseBrowser', true);
+      if (showTrace)
+        configuration.update('showTrace', true);
+      if (envRemoteName)
+        vscode.env.remoteName = envRemoteName;
 
       const extension = new Extension(vscode, vscode.context);
       if (overridePlaywrightVersion)
@@ -221,4 +229,8 @@ export async function selectTestItem(testItem: TestItem) {
 export async function singleWebViewByPanelType(vscode: VSCode, viewType: string) {
   await expect.poll(() => vscode.webViewsByPanelType(viewType)).toHaveLength(1);
   return vscode.webViewsByPanelType(viewType)[0];
+}
+
+export function traceViewerInfo(vscode: VSCode): { type: 'spawn' | 'embedded', serverUrlPrefix?: string, testConfigFile: string } | undefined {
+  return vscode.extensions[0].traceViewerInfoForTest();
 }


### PR DESCRIPTION
Refactoring before introducing embedded mode.

- TraceViewer renamed to SpawnTraceViewer and moved into testModel (see https://github.com/microsoft/playwright-vscode/pull/483#discussion_r1661655108)
- TestModel is now disposable, to ensure all resources are properly released when extension is disposed
