### PR TITLE
[Bug] trace viewer opens in empty state while debugging

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -457,8 +457,11 @@ export class Extension implements RunHooks {
         const testItem = this._testTree.testItemForTest(test);
         if (testItem) {
           testRun.started(testItem);
-          const fullProject = ancestorProject(test);
-          const traceUrl = `${fullProject.outputDir}/.playwright-artifacts-${result.workerIndex}/traces/${test.id}.json`;
+          let traceUrl: string | undefined;
+          if (mode !== 'debug') {
+            const fullProject = ancestorProject(test);
+            traceUrl = `${fullProject.outputDir}/.playwright-artifacts-${result.workerIndex}/traces/${test.id}.json`;
+          }
           (testItem as any)[traceUrlSymbol] = traceUrl;
         }
 


### PR DESCRIPTION
Bug detected in https://github.com/microsoft/playwright-vscode/pull/513#issuecomment-2274495198, but it also happens with public releases of playwright / playwright-vscode.

To reproduce:

- initialize a playwright test project with `npm init playwright@latest`
- in **Testing**, ensure **Show trace viewer** is selected
- in **Testing Explorer**, expand and select a leaf test item, e.g. `has title`
- click the **Debug Test** button

Eventually, it will open the trace viewer app showing **Select test to see the trace**.

This PR tries to fix it by ensuring that trace paths are only associated with corresponding test items when they are not running in debug.

## Environment:

```
  System:
    OS: Windows 11 10.0.22631
    CPU: (8) x64 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
    Memory: 11.99 GB / 31.74 GB
  Binaries:
    Node: 20.15.0 - ~\scoop\apps\nvm\current\nodejs\nodejs\node.EXE
    npm: 10.7.0 - ~\scoop\apps\nvm\current\nodejs\nodejs\npm.CMD
    pnpm: 8.15.4 - ~\AppData\Local\pnpm\pnpm.EXE
  IDEs:
    VSCode: 1.92.0 - C:\Users\rui.figueira\scoop\apps\vscode\current\bin\code.CMD
  npmPackages:
    @playwright/test: ^1.46.0 => 1.46.0

Playwright Test for VSCode: v1.1.7
```