### PR TITLE
chore(trace-viewer): support source location external link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.23.2",
-        "@playwright/test": "^1.46.0-beta-1723801589000",
+        "@playwright/test": "^1.47.0-alpha-2024-08-17",
         "@types/babel__core": "^7.20.3",
         "@types/babel__helper-plugin-utils": "^7.10.2",
         "@types/babel__traverse": "^7.20.3",
@@ -857,13 +857,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
-      "integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
+      "version": "1.47.0-alpha-2024-08-17",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0-alpha-2024-08-17.tgz",
+      "integrity": "sha512-p7lsSzkLMsvSf1SjAvD4hbqND44alnSJOaj5kMx0pOOfb+SlREZosAMXkq8hfB6NgsVYOOm6QJJLuEpNN0W7HQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.46.0"
+        "playwright": "1.47.0-alpha-2024-08-17"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2847,7 +2846,6 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3751,13 +3749,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
-      "integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
+      "version": "1.47.0-alpha-2024-08-17",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0-alpha-2024-08-17.tgz",
+      "integrity": "sha512-c+c8zOtvPiB9iHEgE71kT9bgDPeXzExWqJZHHKUtR+BNamQnQkyiPqZ3YpovQ6qQX4SQ+TUOsfBKXB2VjnCu1g==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.46.0"
+        "playwright-core": "1.47.0-alpha-2024-08-17"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3770,11 +3767,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
-      "integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
+      "version": "1.47.0-alpha-2024-08-17",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0-alpha-2024-08-17.tgz",
+      "integrity": "sha512-nJyT85MFVbPLCs1lFvuxKNsLxykx7kqHYuF/Zzt8umgeb+Q/ju9jXvJkYFiiZyL4hUAKB3X3gcPgYmJKRb/RDQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -5299,12 +5295,12 @@
       "optional": true
     },
     "@playwright/test": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
-      "integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
+      "version": "1.47.0-alpha-2024-08-17",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0-alpha-2024-08-17.tgz",
+      "integrity": "sha512-p7lsSzkLMsvSf1SjAvD4hbqND44alnSJOaj5kMx0pOOfb+SlREZosAMXkq8hfB6NgsVYOOm6QJJLuEpNN0W7HQ==",
       "dev": true,
       "requires": {
-        "playwright": "1.46.0"
+        "playwright": "1.47.0-alpha-2024-08-17"
       }
     },
     "@types/babel__core": {
@@ -7319,19 +7315,19 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
-      "integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
+      "version": "1.47.0-alpha-2024-08-17",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0-alpha-2024-08-17.tgz",
+      "integrity": "sha512-c+c8zOtvPiB9iHEgE71kT9bgDPeXzExWqJZHHKUtR+BNamQnQkyiPqZ3YpovQ6qQX4SQ+TUOsfBKXB2VjnCu1g==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.46.0"
+        "playwright-core": "1.47.0-alpha-2024-08-17"
       }
     },
     "playwright-core": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
-      "integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
+      "version": "1.47.0-alpha-2024-08-17",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0-alpha-2024-08-17.tgz",
+      "integrity": "sha512-nJyT85MFVbPLCs1lFvuxKNsLxykx7kqHYuF/Zzt8umgeb+Q/ju9jXvJkYFiiZyL4hUAKB3X3gcPgYmJKRb/RDQ==",
       "dev": true
     },
     "prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.2",
-    "@playwright/test": "^1.46.0-beta-1723801589000",
+    "@playwright/test": "^1.47.0-alpha-2024-08-17",
     "@types/babel__core": "^7.20.3",
     "@types/babel__helper-plugin-utils": "^7.10.2",
     "@types/babel__traverse": "^7.20.3",

--- a/src/embeddedTraceViewer.ts
+++ b/src/embeddedTraceViewer.ts
@@ -191,8 +191,22 @@ class EmbeddedTraceViewerPanel extends DisposableBase {
       // should be a Uri, but due to https://github.com/microsoft/vscode/issues/85930
       // we pass a string instead
       await this._vscode.env.openExternal(params.url);
+    else if (method === 'openSourceLocation' && params)
+      await this._openSourceFile(params);
     else if (method === 'showErrorMessage')
       await this._vscode.window.showErrorMessage(params.message);
+  }
+
+  private async _openSourceFile({ file, line, column }: { file: string, line: number, column: number }) {
+    try {
+      const document = await this._vscode.workspace.openTextDocument(file);
+      // received line and column are 1-based
+      const pos = new this._vscode.Position(line - 1, column - 1);
+      const selection = new this._vscode.Range(pos, pos);
+      await this._vscode.window.showTextDocument(document, { selection });
+    } catch (e) {
+      // ignore
+    }
   }
 
   private _applyTheme() {


### PR DESCRIPTION
Related: https://github.com/microsoft/playwright/pull/32175

I'll leave it in draft because it requires that `@playwright/test` dependency to be updated to a version that includes https://github.com/microsoft/playwright/commit/b2ccfc3d01f8c1e228ec7af683115696fbf806fa