### PR TITLE
Trace Viewer as webviewView

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,12 @@
           "type": "webview",
           "id": "pw.extension.settingsView",
           "name": "%views.test.pw.extension.settingsView%"
+        },
+        {
+          "type": "webview",
+          "id": "pw.extension.embeddedTraceViewerView",
+          "name": "%views.test.pw.extension.embeddedTraceViewerView%",
+          "when": "config.playwright.showTrace"
         }
       ]
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -17,5 +17,6 @@
   "configuration.playwright.env": "Environment variables to pass to Playwright Test.",
   "configuration.playwright.reuseBrowser": "Show & reuse browser between tests.",
   "configuration.playwright.showTrace": "Show Trace Viewer.",
-  "views.test.pw.extension.settingsView": "Playwright"
+  "views.test.pw.extension.settingsView": "Playwright",
+  "views.test.pw.extension.embeddedTraceViewerView": "Trace Viewer"
 }

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -31,6 +31,7 @@ import { PlaywrightTestCLI } from './playwrightTestCLI';
 import { upstreamTreeItem } from './testTree';
 import { collectTestIds } from './upstream/testTree';
 import { TraceViewer } from './traceViewer';
+import { EmbeddedTraceViewerView } from './embeddedTraceViewer';
 import { EmbeddedTraceViewer } from './embeddedTraceViewer';
 import { SpawnTraceViewer } from './spawnTraceViewer';
 
@@ -673,7 +674,7 @@ export class TestModel extends DisposableBase {
 
     if (settingsModel.embeddedTraceViewer.get()) {
       if (this._checkVersion(1.46, this._vscode.l10n.t('embedded trace viewer'), userGesture))
-        this._traceViewer = new EmbeddedTraceViewer(this._vscode, this._embedder.context.extensionUri, this.config, this._playwrightTest as PlaywrightTestServer);
+        this._traceViewer = new EmbeddedTraceViewer(this._vscode, this.config, this._playwrightTest as PlaywrightTestServer, this._collection.traceViewerView);
     } else {
       if (this._checkVersion(1.35, this._vscode.l10n.t('this feature'), userGesture))
         this._traceViewer = new SpawnTraceViewer(this._vscode, this._embedder.envProvider, this.config);
@@ -700,11 +701,13 @@ export class TestModelCollection extends DisposableBase {
   private _didUpdate: vscodeTypes.EventEmitter<void>;
   readonly onUpdated: vscodeTypes.Event<void>;
   readonly vscode: vscodeTypes.VSCode;
+  readonly traceViewerView: EmbeddedTraceViewerView;
   readonly embedder: TestModelEmbedder;
 
-  constructor(vscode: vscodeTypes.VSCode, embedder: TestModelEmbedder) {
+  constructor(vscode: vscodeTypes.VSCode, traceViewerView: EmbeddedTraceViewerView, embedder: TestModelEmbedder) {
     super();
     this.vscode = vscode;
+    this.traceViewerView = traceViewerView;
     this.embedder = embedder;
     this._didUpdate = new vscode.EventEmitter();
     this.onUpdated = this._didUpdate.event;

--- a/src/traceViewer.ts
+++ b/src/traceViewer.ts
@@ -18,7 +18,6 @@ export type TraceViewer = {
   currentFile(): string | undefined;
   willRunTests(): Promise<void>;
   open(file?: string): Promise<void>;
-  reveal?(): Promise<void>;
   close(): void;
   infoForTest(): Promise<{
     type: string;

--- a/tests/embedded-trace-viewer.spec.ts
+++ b/tests/embedded-trace-viewer.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { enableConfigs, expect, test, selectTestItem, traceViewerInfo, selectConfig, singleWebViewByPanelType } from './utils';
+import { enableConfigs, expect, test, selectTestItem, traceViewerInfo, selectConfig } from './utils';
 
 test.skip(({ showTrace, overridePlaywrightVersion }) => !!overridePlaywrightVersion || showTrace !== 'embedded');
 
@@ -31,9 +31,8 @@ test('should show tracer when test runs', async ({ activate }) => {
   const testItems = testController.findTestItems(/pass/);
   await testController.run(testItems);
 
-  const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-
-  const listItem = webview.frameLocator('iframe').getByTestId('actions-tree').getByRole('listitem');
+  const webView = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
+  const listItem = webView.frameLocator('iframe').getByTestId('actions-tree').getByRole('listitem');
   await expect(
       listItem,
       'action list'
@@ -57,13 +56,13 @@ test('should switch trace when selected test item changes', async ({ activate })
   const testItems = testController.findTestItems(/pass/);
   await testController.run(testItems);
 
-  const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
+  const webView = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
 
   selectTestItem(testItems[0]);
-  await expect(webview.frameLocator('iframe').frameLocator('iframe.snapshot-visible').locator('h1')).toHaveText('Test 1');
+  await expect(webView.frameLocator('iframe').frameLocator('iframe.snapshot-visible').locator('h1')).toHaveText('Test 1');
 
   selectTestItem(testItems[1]);
-  await expect(webview.frameLocator('iframe').frameLocator('iframe.snapshot-visible').locator('h1')).toHaveText('Test 2');
+  await expect(webView.frameLocator('iframe').frameLocator('iframe.snapshot-visible').locator('h1')).toHaveText('Test 2');
 });
 
 test('should toggle between dark and light themes', async ({ activate }) => {
@@ -80,18 +79,18 @@ test('should toggle between dark and light themes', async ({ activate }) => {
   await testController.run(testItems);
 
   const configuration = vscode.workspace.getConfiguration('workbench');
-  const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
+  const webView = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
 
-  await expect(webview.frameLocator('iframe').locator('body')).toHaveClass('dark-mode');
+  await expect(webView.frameLocator('iframe').locator('body')).toHaveClass('dark-mode');
 
   await configuration.update('colorTheme', 'Light Modern', true);
-  await expect(webview.frameLocator('iframe').locator('body')).toHaveClass('light-mode');
+  await expect(webView.frameLocator('iframe').locator('body')).toHaveClass('light-mode');
 
   await configuration.update('colorTheme', 'Dark Modern', true);
-  await expect(webview.frameLocator('iframe').locator('body')).toHaveClass('dark-mode');
+  await expect(webView.frameLocator('iframe').locator('body')).toHaveClass('dark-mode');
 });
 
-test('should reopen trace viewer if closed', async ({ activate }) => {
+test('should show trace viewer if webview is recreated', async ({ activate }) => {
   const { vscode, testController } = await activate({
     'playwright.config.js': `module.exports = { testDir: 'tests' }`,
     'tests/test.spec.ts': `
@@ -101,17 +100,17 @@ test('should reopen trace viewer if closed', async ({ activate }) => {
   });
 
   await testController.expandTestItems(/test.spec/);
-  const testItems = testController.findTestItems(/pass/);
-  await testController.run(testItems);
+  const [testItem] = testController.findTestItems(/pass/);
+  await testController.run();
 
-  const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-  await expect(webview.locator('iframe')).toBeVisible();
+  const webView1 = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
+  await expect(webView1.locator('iframe')).toBeVisible();
 
-  await webview.close();
-  await expect.poll(() => vscode.webViewsByPanelType('playwright.traceviewer.view')).toHaveLength(0);
+  await webView1.close();
 
-  selectTestItem(testItems[0]);
-  await expect.poll(() => vscode.webViewsByPanelType('playwright.traceviewer.view')).toHaveLength(1);
+  const webView2 = await vscode.ensureWebview('pw.extension.embeddedTraceViewerView');
+  selectTestItem(testItem);
+  await expect(webView2.locator('iframe')).toBeVisible();
 });
 
 test('should open snapshot popout', async ({ activate }) => {
@@ -127,8 +126,8 @@ test('should open snapshot popout', async ({ activate }) => {
   const testItems = testController.findTestItems(/pass/);
   await testController.run(testItems);
 
-  const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-  await webview.frameLocator('iframe').getByTitle('Open snapshot in a new tab').click();
+  const webView = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
+  await webView.frameLocator('iframe').getByTitle('Open snapshot in a new tab').click();
 
   await expect.poll(() => vscode.openExternalUrls).toHaveLength(1);
   expect(vscode.openExternalUrls[0]).toContain('snapshot.html');
@@ -155,8 +154,8 @@ test('should not change trace viewer when running tests from different test conf
     await testController.expandTestItems(/test.spec/);
     const testItems = testController.findTestItems(/one/);
     await testController.run(testItems);
-    const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-    const serverUrlPrefix = new URL(await webview.locator('iframe').getAttribute('src') ?? '').origin;
+    const webView = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
+    const serverUrlPrefix = new URL(await webView.locator('iframe').getAttribute('src') ?? '').origin;
     expect(await traceViewerInfo(vscode)).toMatchObject({
       type: 'embedded',
       serverUrlPrefix,
@@ -168,8 +167,8 @@ test('should not change trace viewer when running tests from different test conf
     await testController.expandTestItems(/test.spec/);
     const testItems = testController.findTestItems(/two/);
     await testController.run(testItems);
-    const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-    const serverUrlPrefix = new URL(await webview.locator('iframe').getAttribute('src') ?? '').origin;
+    const webView = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
+    const serverUrlPrefix = new URL(await webView.locator('iframe').getAttribute('src') ?? '').origin;
     expect(await traceViewerInfo(vscode)).toMatchObject({
       type: 'embedded',
       serverUrlPrefix,
@@ -178,7 +177,7 @@ test('should not change trace viewer when running tests from different test conf
   }
 });
 
-test('should close trace viewer when selected test config is disabled', async ({ activate }) => {
+test('should reset trace viewer when selected test config is disabled', async ({ activate }) => {
   const { vscode, testController } = await activate({
     'playwright1.config.js': `module.exports = { testDir: 'tests1' }`,
     'playwright2.config.js': `module.exports = { testDir: 'tests2' }`,
@@ -199,117 +198,16 @@ test('should close trace viewer when selected test config is disabled', async ({
   const testItems = testController.findTestItems(/one/);
   await testController.run(testItems);
 
-  const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-  const serverUrlPrefix = new URL(await webview.locator('iframe').getAttribute('src') ?? '').origin;
-
   selectTestItem(testItems[0]);
   expect(await traceViewerInfo(vscode)).toMatchObject({
     type: 'embedded',
-    serverUrlPrefix,
     testConfigFile: expect.stringMatching('playwright1.config.js'),
   });
 
   // disables playwright1.config.js
   await enableConfigs(vscode, ['playwright2.config.js']);
-  // config should close trace viewer
-  await expect.poll(() => vscode.webViewsByPanelType('playwright.traceviewer.view')).toHaveLength(0);
   expect.poll(() => traceViewerInfo(vscode)).toBeUndefined();
 });
-
-test('should reopen trace viewer when another test config is selected', async ({ activate }) => {
-  const { vscode, testController } = await activate({
-    'playwright1.config.js': `module.exports = { testDir: 'tests1' }`,
-    'playwright2.config.js': `module.exports = { testDir: 'tests2' }`,
-    'tests1/test.spec.ts': `
-      import { test } from '@playwright/test';
-      test('one', () => {});
-      `,
-    'tests2/test.spec.ts': `
-      import { test } from '@playwright/test';
-      test('one', () => {});
-      `,
-  });
-
-  await enableConfigs(vscode, ['playwright1.config.js', 'playwright2.config.js']);
-  await selectConfig(vscode, 'playwright1.config.js');
-
-  await testController.expandTestItems(/test.spec/);
-  const testItems = testController.findTestItems(/one/);
-  await testController.run(testItems);
-
-  const webview1 = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-  expect(await traceViewerInfo(vscode)).toMatchObject({
-    type: 'embedded',
-    serverUrlPrefix: new URL(await webview1.locator('iframe').getAttribute('src') ?? '').origin,
-    testConfigFile: expect.stringMatching('playwright1.config.js'),
-  });
-
-  await selectConfig(vscode, 'playwright2.config.js');
-  selectTestItem(testItems[0]);
-  await webview1.waitForEvent('close');
-
-  const webview2 = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-  expect(await traceViewerInfo(vscode)).toMatchObject({
-    type: 'embedded',
-    serverUrlPrefix: new URL(await webview2.locator('iframe').getAttribute('src') ?? '').origin,
-    testConfigFile: expect.stringMatching('playwright2.config.js'),
-  });
-});
-
-test('should not open trace viewer if selected test item did not run', async ({ activate }) => {
-  const { vscode, testController } = await activate({
-    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
-    'tests/test.spec.ts': `
-      import { test } from '@playwright/test';
-      test('should pass', async () => {});
-    `,
-  });
-
-  await testController.expandTestItems(/test.spec/);
-  const testItems = testController.findTestItems(/pass/);
-
-  selectTestItem(testItems[0]);
-
-  // wait to ensure no async webview is opened
-  await new Promise(f => setTimeout(f, 1000));
-  await expect.poll(() => vscode.webViewsByPanelType('playwright.traceviewer.view')).toHaveLength(0);
-  expect(vscode.warnings).toHaveLength(0);
-});
-
-test('should fallback to spawn trace viewer if embedded not enabled', async ({ activate }) => {
-  const { vscode, testController } = await activate({
-    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
-    'tests/test.spec.ts': `
-      import { test } from '@playwright/test';
-      test('should pass', async () => {});
-    `,
-  });
-
-  const configuration = vscode.workspace.getConfiguration('playwright');
-  configuration.update('embeddedTraceViewer', false, true);
-
-  await testController.expandTestItems(/test.spec/);
-  const testItems = testController.findTestItems(/pass/);
-  await testController.run(testItems);
-
-  await expect(testController).toHaveTestTree(`
-    -   tests
-      -   test.spec.ts
-        - ✅ should pass [2:0]
-  `);
-
-  // wait to ensure no async webview is opened
-  await new Promise(f => setTimeout(f, 1000));
-  await expect.poll(() => vscode.webViewsByPanelType('playwright.traceviewer.view')).toHaveLength(0);
-  expect(vscode.warnings).toHaveLength(0);
-
-  await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
-    type: 'spawn',
-    serverUrlPrefix: expect.anything(),
-    testConfigFile: expect.stringContaining('playwright.config.js')
-  });
-});
-
 
 test('should switch to spawn trace viewer if embedded is disabled and test item is selected', async ({ activate }) => {
   const { vscode, testController } = await activate({
@@ -370,14 +268,14 @@ test('should restore webview state when moving', async ({ activate }) => {
 
   selectTestItem(testItems[0]);
 
-  const webview = await singleWebViewByPanelType(vscode, 'playwright.traceviewer.view')!;
-  await vscode.changeVisibility(webview, 'hidden');
+  const webView = vscode.webViews.get('pw.extension.embeddedTraceViewerView')!;
+  await vscode.changeVisibility(webView, 'hidden');
 
-  await expect(webview).toHaveURL(/hidden/);
+  await expect(webView).toHaveURL(/hidden/);
 
-  await vscode.changeVisibility(webview, 'visible');
+  await vscode.changeVisibility(webView, 'visible');
 
-  const listItem = webview.frameLocator('iframe').getByTestId('actions-tree').getByRole('listitem');
+  const listItem = webView.frameLocator('iframe').getByTestId('actions-tree').getByRole('listitem');
   await expect(
       listItem,
       'action list'
@@ -385,5 +283,4 @@ test('should restore webview state when moving', async ({ activate }) => {
     /Before Hooks[\d.]+m?s/,
     /After Hooks[\d.]+m?s/,
   ]);
-
 });

--- a/tests/trace-viewer.spec.ts
+++ b/tests/trace-viewer.spec.ts
@@ -112,7 +112,7 @@ test('should refresh trace viewer while test is running', async ({ activate, cre
   });
 });
 
-test('should close trace viewer if test configs refreshed', async ({ activate, showTrace }) => {
+test('should reset trace viewer if test configs refreshed', async ({ activate, showTrace }) => {
   const { vscode, testController } = await activate({
     'playwright.config.js': `module.exports = { testDir: 'tests' }`,
     'tests/test.spec.ts': `
@@ -130,16 +130,15 @@ test('should close trace viewer if test configs refreshed', async ({ activate, s
     traceFile: expect.stringContaining('pass'),
   });
 
-  await testController.refreshHandler(null);
+  await testController.refreshHandler!(null);
 
   await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
     type: showTrace,
     traceFile: undefined,
-    visible: false,
   });
 });
 
-test('should open new trace viewer when another test config is selected', async ({ activate, showTrace }) => {
+test('should reset trace viewer when another test config is selected', async ({ activate, showTrace }) => {
   const { vscode, testController } = await activate({
     'playwright1.config.js': `module.exports = { testDir: 'tests1' }`,
     'playwright2.config.js': `module.exports = { testDir: 'tests2' }`,
@@ -164,18 +163,17 @@ test('should open new trace viewer when another test config is selected', async 
 
   await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
     type: showTrace,
-    serverUrlPrefix: expect.stringContaining('http'),
     testConfigFile: expect.stringContaining('playwright1.config.js'),
+    traceFile: expect.anything(),
   });
-  const serverUrlPrefix1 = traceViewerInfo(vscode);
 
-  // closes opened trace viewer
+  // resets opened trace viewer
   await selectConfig(vscode, 'playwright2.config.js');
 
   await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
     type: showTrace,
-    traceFile: undefined,
-    visible: false,
+    testConfigFile: expect.stringContaining('playwright2.config.js'),
+    traceFile: undefined
   });
 
   // opens trace viewer from selected test config
@@ -183,10 +181,7 @@ test('should open new trace viewer when another test config is selected', async 
 
   await expect.poll(() => traceViewerInfo(vscode)).toMatchObject({
     type: showTrace,
-    serverUrlPrefix: expect.stringContaining('http'),
     testConfigFile: expect.stringContaining('playwright2.config.js'),
+    traceFile: expect.anything(),
   });
-  const serverUrlPrefix2 = traceViewerInfo(vscode);
-
-  expect(serverUrlPrefix2).not.toBe(serverUrlPrefix1);
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -250,11 +250,6 @@ export async function selectTestItem(testItem: TestItem) {
   testItem.testController.vscode.extensions[0].fireTreeItemSelectedForTest(testItem);
 }
 
-export async function singleWebViewByPanelType(vscode: VSCode, viewType: string) {
-  await expect.poll(() => vscode.webViewsByPanelType(viewType)).toHaveLength(1);
-  return vscode.webViewsByPanelType(viewType)[0];
-}
-
 export async function traceViewerInfo(vscode: VSCode): Promise<{ type: 'spawn' | 'embedded', serverUrlPrefix?: string, testConfigFile: string, traceFile: string } | undefined> {
   return await vscode.extensions[0].traceViewerInfoForTest();
 }


### PR DESCRIPTION
As requested in https://github.com/microsoft/playwright-vscode/pull/513#discussion_r1714624850

It's still in draft:

- when view is disposed or it isn't resolved yet (e.g view was explicitly closed and then VS code was restarted), I couldn't find a way of programatically show the view. I need to explicitly open the view with "View: Open View" command. I even tried to execute that command programatically, but it always shows a quick pick to pick the view, I cannot pass the view ID as a parameter
- I added a `when` condition to this view's contribution point, but it only checks `showTrace` configuration because `embeddedTraceViewer` is not a declarative configuration yet
- I already separated testing harness changes into a different commit, so if you want it in a different PR it's easy to create (for the time being, I'm letting it this way to understand the context of the changes, which are mostly to support dynamic `webview.html` changes)