### PR TITLE
chore: ensure disposables are disposed

### DIFF
--- a/src/debugHighlight.ts
+++ b/src/debugHighlight.ts
@@ -41,6 +41,8 @@ export class DebugHighlight {
 
     const self = this;
     this._disposables = [
+      this._onErrorInDebuggerEmitter,
+      this._onStdOutEmitter,
       vscode.debug.onDidStartDebugSession(session => {
         if (isPlaywrightSession(session))
           this._debugSessions.set(session.id, session);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -224,6 +224,7 @@ export class Extension implements RunHooks {
         if (event.affectsConfiguration('playwright.env'))
           this._rebuildModels(false);
       }),
+      this._testTree,
       this._models,
       this._models.onUpdated(() => this._modelsUpdated()),
       this._treeItemObserver.onTreeItemSelected(item => this._treeItemSelected(item)),
@@ -809,6 +810,7 @@ class TreeItemObserver implements vscodeTypes.Disposable{
 
   dispose() {
     clearTimeout(this._timeout);
+    this._treeItemSelected.dispose();
   }
 
   selectedTreeItem(): vscodeTypes.TreeItem | null {

--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -56,10 +56,15 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
     this.onHighlightRequestedForTest = this._onHighlightRequestedForTestEvent.event;
     this._settingsModel = settingsModel;
 
-    this._disposables.push(settingsModel.showBrowser.onChange(value => {
-      if (!value)
-        this.closeAllBrowsers();
-    }));
+    this._disposables.push(
+        this._onPageCountChangedEvent,
+        this._onHighlightRequestedForTestEvent,
+        this._onRunningTestsChangedEvent,
+        settingsModel.showBrowser.onChange(value => {
+          if (!value)
+            this.closeAllBrowsers();
+        }),
+    );
   }
 
   dispose() {

--- a/src/settingsModel.ts
+++ b/src/settingsModel.ts
@@ -58,14 +58,17 @@ export class SettingsModel extends DisposableBase {
     this.showTrace = this._createSetting('showTrace');
     this.embeddedTraceViewer = this._createHiddenSetting('embeddedTraceViewer', false);
 
-    this.showBrowser.onChange(enabled => {
-      if (enabled && this.showTrace.get())
-        this.showTrace.set(false);
-    });
-    this.showTrace.onChange(enabled => {
-      if (enabled && this.showBrowser.get())
-        this.showBrowser.set(false);
-    });
+    this._disposables.push(
+        this._onChange,
+        this.showBrowser.onChange(enabled => {
+          if (enabled && this.showTrace.get())
+            this.showTrace.set(false);
+        }),
+        this.showTrace.onChange(enabled => {
+          if (enabled && this.showBrowser.get())
+            this.showBrowser.set(false);
+        }),
+    );
 
     this._modernize();
   }
@@ -138,6 +141,7 @@ class PersistentSetting<T> extends SettingBase<T> {
 
     const settingFQN = `playwright.${settingName}`;
     this._disposables = [
+      this._onChange,
       vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration(settingFQN))
           this._onChange.fire(this.get());

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -708,6 +708,9 @@ export class TestModelCollection extends DisposableBase {
     this.embedder = embedder;
     this._didUpdate = new vscode.EventEmitter();
     this.onUpdated = this._didUpdate.event;
+    this._disposables = [
+      this._didUpdate,
+    ];
   }
 
   setModelEnabled(configFile: string, enabled: boolean, userGesture?: boolean) {

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -349,6 +349,7 @@ class TestRunProfile {
 
   dispose() {
     this.runProfiles.splice(this.runProfiles.indexOf(this), 1);
+    this.didChangeDefault.dispose();
   }
 }
 
@@ -559,6 +560,11 @@ export class TestController {
     const profile = this.runProfiles.find(p => p.kind === this.vscode.TestRunProfileKind.Debug)!;
     return profile.run(include, exclude);
   }
+
+  dispose() {
+    this.didChangeTestItem.dispose();
+    this._didCreateTestRun.dispose();
+  }
 }
 
 type Decoration = { type?: number, range: Range, renderOptions?: any };
@@ -653,6 +659,9 @@ class FileSystemWatcher {
 
   dispose() {
     this.vscode.fsWatchers.delete(this);
+    this.didCreate.dispose();
+    this.didChange.dispose();
+    this.didDelete.dispose();
   }
 }
 
@@ -745,6 +754,11 @@ class Debug {
         ],
       }
     });
+  }
+
+  dispose() {
+    this._didStartDebugSession.dispose();
+    this._didTerminateDebugSession.dispose();
   }
 }
 
@@ -913,6 +927,16 @@ export class VSCode {
       this.commandLog.push(name);
     };
     this.debug = new Debug();
+    this.context.subscriptions.push(
+        this.debug,
+        this._didChangeActiveTextEditor,
+        this._didChangeVisibleTextEditors,
+        this._didChangeTextEditorSelection,
+        this._didChangeWorkspaceFolders,
+        this._didChangeTextDocument,
+        this._didChangeConfiguration,
+        this._didShowInputBox,
+    );
 
     const diagnosticsCollections: DiagnosticsCollection[] = [];
     this.languages.registerHoverProvider = (language: string, provider: HoverProvider) => {


### PR DESCRIPTION
As a follow up to trace viewer changes, I did a poor man's leak analysis of disposables. I found some disposables left unhandled, mostly `EventEmitter`, so this PR is to fix them.

For the record, this is the script-as-test I did to catch those leaks (I didn't include it in this PR because it's just a best effort and not something we should rely on to catch leakages, but I can include it if you think it's worth it):


```js
import { expect, test } from './utils';
import * as vscodeTypes from '../src/vscodeTypes';

function isDisposable(o: any): o is vscodeTypes.Disposable {
  return typeof o['dispose'] === 'function';
}

type VisitPath = [any, string[]];

function visit(obj: any, fn: (...o: VisitPath) => any) {
  function innerVisit([obj, props]: VisitPath, visited = new Set()) {
    if (obj === null || obj === undefined || !['object', 'function'].includes(typeof obj) || visited.has(obj))
      return;

    visited.add(obj);
    fn(obj, props);

    for (const prop in obj)
      innerVisit([obj[prop], [prop, ...props]], visited);
  }

  return innerVisit([obj, []]);
}

function pathToString([obj, props]: VisitPath) {
  return [obj.constructor?.name ?? obj.toString(), ...props].join(' <- ');
}

test('should dispose all vscode disposables', async ({ activate }) => {
  const { vscode } = await activate({
    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
    'tests/test.spec.ts': `
      import { test, expect } from '@playwright/test';
      test('pass', async () => {});
    `,
  });

  const disposables = new Map<vscodeTypes.Disposable, string[]>();
  const disposed = new Set<vscodeTypes.Disposable>();

  visit({ vscode }, (obj, props) => {
    if (!isDisposable(obj))
      return;
    obj.dispose = new Proxy(obj.dispose, {
      apply(target, thisArg, argArray) {
        disposed.add(thisArg);
        return Reflect.apply(target, thisArg, argArray);
      },
    });
    disposables.set(obj, props);
  });

  vscode.dispose();

  const undisposed = [...disposables.entries()].filter(([k]) => !disposed.has(k)).map(pathToString);
  expect(undisposed).toEqual([]);
});
```