### PR TITLE
feat: add toggle for always recreating global setup

### DIFF
--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -17,7 +17,7 @@
   "Select Playwright Config": "Playwright-Konfiguration auswählen",
   "Show browser mode does not work in remote vscode": "Der Browser kann nicht mit Remote VSCode angezeigt werden", 
   "Show browser": "Browser anzeigen",
-  "Don't reuse global setup": "Globales Setup nicht wiederverwenden",
+  "Run global setup on each run": "Globales Setup jedesmal ausführen",
   "Show trace viewer": "Trace Viewer anzeigen",
   "Start dev server": "Entwicklungsserver starten",
   "Stop dev server": "Entwicklungsserver stoppen",

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -17,6 +17,7 @@
   "Select Playwright Config": "Playwright-Konfiguration auswählen",
   "Show browser mode does not work in remote vscode": "Der Browser kann nicht mit Remote VSCode angezeigt werden", 
   "Show browser": "Browser anzeigen",
+  "Don't reuse global setup": "Globales Setup nicht wiederverwenden",
   "Show trace viewer": "Trace Viewer anzeigen",
   "Start dev server": "Entwicklungsserver starten",
   "Stop dev server": "Entwicklungsserver stoppen",

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -17,6 +17,7 @@
   "Select Playwright Config": "Sélectionner la configuration Playwright",
   "Show browser mode does not work in the Web mode": "Le mode affichage de navigateur ne peut être utilisé en mode Web",
   "Show browser": "Afficher le navigateur",
+  "Don't reuse global setup": "Ne pas réutiliser setup globale",
   "Show trace viewer": "Afficher le Trace Viewer",
   "Start dev server": "Démarrer le serveur de développement",
   "Stop dev server": "Arrêter le serveur de développement",

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -17,7 +17,7 @@
   "Select Playwright Config": "Sélectionner la configuration Playwright",
   "Show browser mode does not work in the Web mode": "Le mode affichage de navigateur ne peut être utilisé en mode Web",
   "Show browser": "Afficher le navigateur",
-  "Don't reuse global setup": "Ne pas réutiliser setup globale",
+  "Run global setup on each run": "Exécuter la configuration globale chaque course",
   "Show trace viewer": "Afficher le Trace Viewer",
   "Start dev server": "Démarrer le serveur de développement",
   "Stop dev server": "Arrêter le serveur de développement",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -17,7 +17,7 @@
   "Select Playwright Config": "Select Playwright Config",
   "Show browser mode does not work in remote vscode": "Show browser mode does not work in remote vscode",
   "Show browser": "Show browser",
-  "Don't reuse global setup": "Don't reuse global setup",
+  "Run global setup on each run": "Run global setup on each run",
   "Show trace viewer": "Show trace viewer",
   "Start dev server": "Start dev server",
   "Stop dev server": "Stop dev server",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -17,6 +17,7 @@
   "Select Playwright Config": "Select Playwright Config",
   "Show browser mode does not work in remote vscode": "Show browser mode does not work in remote vscode",
   "Show browser": "Show browser",
+  "Don't reuse global setup": "Don't reuse global setup",
   "Show trace viewer": "Show trace viewer",
   "Start dev server": "Start dev server",
   "Stop dev server": "Stop dev server",

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -17,6 +17,7 @@
   "Select Playwright Config": "选择 Playwright 配置",
   "Show browser mode does not work in remote vscode": "显示浏览器模式在远程vscode中不起作用",
   "Show browser": "显示浏览器",
+  "Don't reuse global setup": "不要重复使用全局设置",
   "Show trace viewer": "显示 Trace Viewer",
   "Start dev server": "启动 dev 服务器",
   "Stop dev server": "停止 dev 服务器",

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -17,7 +17,7 @@
   "Select Playwright Config": "选择 Playwright 配置",
   "Show browser mode does not work in remote vscode": "显示浏览器模式在远程vscode中不起作用",
   "Show browser": "显示浏览器",
-  "Don't reuse global setup": "不要重复使用全局设置",
+  "Run global setup on each run": "每次运行全局设置",
   "Show trace viewer": "显示 Trace Viewer",
   "Start dev server": "启动 dev 服务器",
   "Stop dev server": "停止 dev 服务器",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
       },
       {
         "category": "Test",
+        "command": "pw.extension.toggle.dontReuseGlobalSetup",
+        "title": "%contributes.command.pw.extension.toggle.dontReuseGlobalSetup%"
+      },
+      {
+        "category": "Test",
         "command": "pw.extension.command.runGlobalSetup",
         "title": "%contributes.command.pw.extension.command.runGlobalSetup%"
       },
@@ -113,6 +118,11 @@
           "type": "boolean",
           "default": false,
           "description": "%configuration.playwright.showTrace%"
+        },
+        "playwright.dontReuseGlobalSetup": {
+          "type": "boolean",
+          "default": false,
+          "description": "%configuration.playwright.dontReuseGlobalSetup%"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
       },
       {
         "category": "Test",
-        "command": "pw.extension.toggle.dontReuseGlobalSetup",
-        "title": "%contributes.command.pw.extension.toggle.dontReuseGlobalSetup%"
+        "command": "pw.extension.toggle.runGlobalSetupOnEachRun",
+        "title": "%contributes.command.pw.extension.toggle.runGlobalSetupOnEachRun%"
       },
       {
         "category": "Test",
@@ -119,10 +119,10 @@
           "default": false,
           "description": "%configuration.playwright.showTrace%"
         },
-        "playwright.dontReuseGlobalSetup": {
+        "playwright.runGlobalSetupOnEachRun": {
           "type": "boolean",
           "default": false,
-          "description": "%configuration.playwright.dontReuseGlobalSetup%"
+          "description": "%configuration.playwright.runGlobalSetupOnEachRun%"
         }
       }
     },

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -14,10 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "Playwright Konfigurationen umschalten",
   "contributes.command.pw.extension.toggle.reuseBrowser": "Wiederverwendung des Playwright Browsers umschalten",
   "contributes.command.pw.extension.toggle.showTrace": "Playwright Trace Viewer umschalten",
-  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "Wiederverwendung des globalen Setups umschalten",
+  "contributes.command.pw.extension.toggle.runGlobalSetupOnEachRun": "Wiederverwendung des globalen Setups umschalten",
   "configuration.playwright.env": "Umgebungsvariablen, die an Playwright Test übergeben werden.",
   "configuration.playwright.reuseBrowser": "Browser zwischen Tests anzeigen & wiederverwenden.",
   "configuration.playwright.showTrace": "Trace Viewer anzeigen.",
-  "configuration.playwright.dontReuseGlobalSetup": "Globales Setup nicht wiederverwenden.",
+  "configuration.playwright.runGlobalSetupOnEachRun": "Globales Setup nicht wiederverwenden.",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -14,8 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "Playwright Konfigurationen umschalten",
   "contributes.command.pw.extension.toggle.reuseBrowser": "Wiederverwendung des Playwright Browsers umschalten",
   "contributes.command.pw.extension.toggle.showTrace": "Playwright Trace Viewer umschalten",
+  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "Wiederverwendung des globalen Setups umschalten",
   "configuration.playwright.env": "Umgebungsvariablen, die an Playwright Test übergeben werden.",
   "configuration.playwright.reuseBrowser": "Browser zwischen Tests anzeigen & wiederverwenden.",
   "configuration.playwright.showTrace": "Trace Viewer anzeigen.",
+  "configuration.playwright.dontReuseGlobalSetup": "Globales Setup nicht wiederverwenden.",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -14,10 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "Sélectionner les configurations Playwright",
   "contributes.command.pw.extension.toggle.reuseBrowser": "Activer/désactiver la réutilisation du navigateur",
   "contributes.command.pw.extension.toggle.showTrace": "Activer/désactiver Playwright Trace Viewer",
-  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "Activer/désactiver la réutilisation de la setup globale",
+  "contributes.command.pw.extension.toggle.runGlobalSetupOnEachRun": "Activer/désactiver la réutilisation de la setup globale",
   "configuration.playwright.env": "Variables d'environnement à transmettre à Playwright Test.",
   "configuration.playwright.reuseBrowser": "Afficher et réutiliser le navigateur entre les tests.",
   "configuration.playwright.showTrace": "Afficher les traces avec Trace Viewer.",
-  "configuration.playwright.dontReuseGlobalSetup": "Ne pas réutiliser la setup globale.",
+  "configuration.playwright.runGlobalSetupOnEachRun": "Ne pas réutiliser la setup globale.",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -14,8 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "Sélectionner les configurations Playwright",
   "contributes.command.pw.extension.toggle.reuseBrowser": "Activer/désactiver la réutilisation du navigateur",
   "contributes.command.pw.extension.toggle.showTrace": "Activer/désactiver Playwright Trace Viewer",
+  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "Activer/désactiver la réutilisation de la setup globale",
   "configuration.playwright.env": "Variables d'environnement à transmettre à Playwright Test.",
   "configuration.playwright.reuseBrowser": "Afficher et réutiliser le navigateur entre les tests.",
   "configuration.playwright.showTrace": "Afficher les traces avec Trace Viewer.",
+  "configuration.playwright.dontReuseGlobalSetup": "Ne pas réutiliser la setup globale.",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,10 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "Toggle Playwright configs",
   "contributes.command.pw.extension.toggle.reuseBrowser": "Toggle Playwright browser reuse",
   "contributes.command.pw.extension.toggle.showTrace": "Toggle Playwright Trace Viewer",
-  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "Toggle Playwright global setup reuse",
+  "contributes.command.pw.extension.toggle.runGlobalSetupOnEachRun": "Toggle Playwright global setup reuse",
   "configuration.playwright.env": "Environment variables to pass to Playwright Test.",
   "configuration.playwright.reuseBrowser": "Show & reuse browser between tests.",
   "configuration.playwright.showTrace": "Show Trace Viewer.",
-  "configuration.playwright.dontReuseGlobalSetup": "Don't reuse global setup.",
+  "configuration.playwright.runGlobalSetupOnEachRun": "Run global setup on each run.",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,8 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "Toggle Playwright configs",
   "contributes.command.pw.extension.toggle.reuseBrowser": "Toggle Playwright browser reuse",
   "contributes.command.pw.extension.toggle.showTrace": "Toggle Playwright Trace Viewer",
+  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "Toggle Playwright global setup reuse",
   "configuration.playwright.env": "Environment variables to pass to Playwright Test.",
   "configuration.playwright.reuseBrowser": "Show & reuse browser between tests.",
   "configuration.playwright.showTrace": "Show Trace Viewer.",
+  "configuration.playwright.dontReuseGlobalSetup": "Don't reuse global setup.",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -14,8 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "选择 Playwright 配置",
   "contributes.command.pw.extension.toggle.reuseBrowser": "是否复用 Playwright 浏览器",
   "contributes.command.pw.extension.toggle.showTrace": "是否显示 Playwright 浏览器的跟踪",
+  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "切换 Playwright 全局设置的重用",
   "configuration.playwright.env": "Playwright Test 运行环境变量",
   "configuration.playwright.reuseBrowser": "在测试用例间显示并复用 Playwright 浏览器",
   "configuration.playwright.showTrace": "显示 Playwright 浏览器的跟踪",
+  "configuration.playwright.dontReuseGlobalSetup": "不要重复使用全局设置",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -14,10 +14,10 @@
   "contributes.command.pw.extension.command.toggleModels": "选择 Playwright 配置",
   "contributes.command.pw.extension.toggle.reuseBrowser": "是否复用 Playwright 浏览器",
   "contributes.command.pw.extension.toggle.showTrace": "是否显示 Playwright 浏览器的跟踪",
-  "contributes.command.pw.extension.toggle.dontReuseGlobalSetup": "切换 Playwright 全局设置的重用",
+  "contributes.command.pw.extension.toggle.runGlobalSetupOnEachRun": "切换 Playwright 全局设置的重用",
   "configuration.playwright.env": "Playwright Test 运行环境变量",
   "configuration.playwright.reuseBrowser": "在测试用例间显示并复用 Playwright 浏览器",
   "configuration.playwright.showTrace": "显示 Playwright 浏览器的跟踪",
-  "configuration.playwright.dontReuseGlobalSetup": "不要重复使用全局设置",
+  "configuration.playwright.runGlobalSetupOnEachRun": "不要重复使用全局设置",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/src/settingsModel.ts
+++ b/src/settingsModel.ts
@@ -43,7 +43,7 @@ export class SettingsModel extends DisposableBase {
   private _onChange: vscodeTypes.EventEmitter<void>;
   showBrowser: Setting<boolean>;
   showTrace: Setting<boolean>;
-  dontReuseGlobalSetup: Setting<boolean>;
+  runGlobalSetupOnEachRun: Setting<boolean>;
   embeddedTraceViewer: Setting<boolean>;
   private _isUnderTest: boolean;
 
@@ -57,7 +57,7 @@ export class SettingsModel extends DisposableBase {
 
     this.showBrowser = this._createSetting('reuseBrowser');
     this.showTrace = this._createSetting('showTrace');
-    this.dontReuseGlobalSetup = this._createSetting('dontReuseGlobalSetup');
+    this.runGlobalSetupOnEachRun = this._createSetting('runGlobalSetupOnEachRun');
     this.embeddedTraceViewer = this._createHiddenSetting('embeddedTraceViewer', false);
 
     this.showBrowser.onChange(enabled => {

--- a/src/settingsModel.ts
+++ b/src/settingsModel.ts
@@ -43,6 +43,7 @@ export class SettingsModel extends DisposableBase {
   private _onChange: vscodeTypes.EventEmitter<void>;
   showBrowser: Setting<boolean>;
   showTrace: Setting<boolean>;
+  dontReuseGlobalSetup: Setting<boolean>;
   embeddedTraceViewer: Setting<boolean>;
   private _isUnderTest: boolean;
 
@@ -56,6 +57,7 @@ export class SettingsModel extends DisposableBase {
 
     this.showBrowser = this._createSetting('reuseBrowser');
     this.showTrace = this._createSetting('showTrace');
+    this.dontReuseGlobalSetup = this._createSetting('dontReuseGlobalSetup');
     this.embeddedTraceViewer = this._createHiddenSetting('embeddedTraceViewer', false);
 
     this.showBrowser.onChange(enabled => {

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -85,6 +85,7 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
 
     this._disposables.push(this._settingsModel.onChange(() => {
       this._updateSettings();
+      this._updateActions();
     }));
 
     this._disposables.push(webviewView.onDidChangeVisibility(() => {
@@ -277,6 +278,12 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
           <label>
             <input type="checkbox" setting="showTrace"></input>
             ${vscode.l10n.t('Show trace viewer')}
+          </label>
+        </div>
+        <div>
+          <label>
+            <input type="checkbox" setting="dontReuseGlobalSetup"></input>
+            ${vscode.l10n.t("Don't reuse global setup")}
           </label>
         </div>
       </div>

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -145,6 +145,7 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
         text: this._vscode.l10n.t('Run global setup'),
         location: 'rareActions',
         disabled: !this._models.selectedModel() || !this._models.selectedModel()!.canRunGlobalHooks('setup'),
+        hidden: this._settingsModel.runGlobalSetupOnEachRun.get(),
       },
       {
         command: 'pw.extension.command.runGlobalTeardown',
@@ -152,6 +153,7 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
         text: this._vscode.l10n.t('Run global teardown'),
         location: 'rareActions',
         disabled: !this._models.selectedModel() || !this._models.selectedModel()!.canRunGlobalHooks('teardown'),
+        hidden: this._settingsModel.runGlobalSetupOnEachRun.get(),
       },
       {
         command: 'pw.extension.command.startDevServer',

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -286,7 +286,6 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
       <div class="section-header">${vscode.l10n.t('TOOLS')}</div>
       <div id="actions" class="list"></div>
       <div class="section-header">${vscode.l10n.t('SETUP')}</div>
-      <div id="rareActions" class="list"></div>
       <div class="list">
         <div>
           <label>
@@ -295,6 +294,7 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
           </label>
         </div>
       </div>
+      <div id="rareActions" class="list"></div>
     </body>
     <script nonce="${nonce}">
       let selectConfig;

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -280,17 +280,19 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
             ${vscode.l10n.t('Show trace viewer')}
           </label>
         </div>
-        <div>
-          <label>
-            <input type="checkbox" setting="dontReuseGlobalSetup"></input>
-            ${vscode.l10n.t("Don't reuse global setup")}
-          </label>
-        </div>
       </div>
       <div class="section-header">${vscode.l10n.t('TOOLS')}</div>
       <div id="actions" class="list"></div>
       <div class="section-header">${vscode.l10n.t('SETUP')}</div>
       <div id="rareActions" class="list"></div>
+      <div class="list">
+        <div>
+          <label>
+            <input type="checkbox" setting="runGlobalSetupOnEachRun"></input>
+            ${vscode.l10n.t('Run global setup on each run')}
+          </label>
+        </div>
+      </div>
     </body>
     <script nonce="${nonce}">
       let selectConfig;

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -453,7 +453,7 @@ export class TestModel extends DisposableBase {
       return false;
 
     if (type === 'setup') {
-      if (this._embedder.settingsModel.dontReuseGlobalSetup.get())
+      if (this._embedder.settingsModel.runGlobalSetupOnEachRun.get())
         return true;
 
       return !this._ranGlobalSetup;

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -449,8 +449,16 @@ export class TestModel extends DisposableBase {
   }
 
   canRunGlobalHooks(type: 'setup' | 'teardown') {
-    if (type === 'setup')
-      return !this._useLegacyCLIDriver && !this._ranGlobalSetup;
+    if (this._useLegacyCLIDriver)
+      return false;
+
+    if (type === 'setup') {
+      if (this._embedder.settingsModel.dontReuseGlobalSetup.get())
+        return true;
+
+      return !this._ranGlobalSetup;
+    }
+
     return this._ranGlobalSetup;
   }
 
@@ -466,7 +474,7 @@ export class TestModel extends DisposableBase {
     if (!this.canRunGlobalHooks(type))
       return 'passed';
     if (type === 'setup') {
-      if (this._ranGlobalSetup)
+      if (!this.canRunGlobalHooks('setup'))
         return 'passed';
       const status = await this._playwrightTest.runGlobalHooks('setup', testListener);
       if (status === 'passed')

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -1079,6 +1079,7 @@ export class VSCode {
       'playwright.reuseBrowser': false,
       'playwright.showTrace': false,
       'playwright.embeddedTraceViewer': false,
+      'playwright.dontReuseGlobalSetup': false,
       'workbench.colorTheme': 'Dark Modern',
     };
     this.workspace.getConfiguration = (scope: string) => {

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -1079,7 +1079,7 @@ export class VSCode {
       'playwright.reuseBrowser': false,
       'playwright.showTrace': false,
       'playwright.embeddedTraceViewer': false,
-      'playwright.dontReuseGlobalSetup': false,
+      'playwright.runGlobalSetupOnEachRun': false,
       'workbench.colorTheme': 'Dark Modern',
     };
     this.workspace.getConfiguration = (scope: string) => {

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1247,7 +1247,7 @@ test('should force workers=1 when reusing the browser', async ({ activate, showB
   expect(testRun.renderLog({ output: true })).toContain('Running 3 tests using 1 worker');
 });
 
-test.describe('dontReuseGlobalSetup', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32121' } }, () => {
+test.describe('runGlobalSetupOnEachRun', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32121' } }, () => {
   test.skip(({ overridePlaywrightVersion }) => !!overridePlaywrightVersion, 'old world doesnt have globalSetup');
 
   function expectOrdering(log: string, items: string[]) {
@@ -1290,8 +1290,8 @@ test.describe('dontReuseGlobalSetup', { annotation: { type: 'issue', description
     expect(secondRun).not.toContain('RUNNING TEARDOWN');
   });
 
-  test('should always run global setup and teardown if dontReuseGlobalSetup is enabled', async ({ activate }) => {
-    const { testController } = await activate(files, { dontReuseGlobalSetup: true });
+  test('should always run global setup and teardown if runGlobalSetupOnEachRun is enabled', async ({ activate }) => {
+    const { testController } = await activate(files, { runGlobalSetupOnEachRun: true });
 
     const firstRun = (await testController.run()).renderOutput();
     expectOrdering(firstRun, ['RUNNING SETUP', 'RUNNING TEST']);

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1247,7 +1247,7 @@ test('should force workers=1 when reusing the browser', async ({ activate, showB
   expect(testRun.renderLog({ output: true })).toContain('Running 3 tests using 1 worker');
 });
 
-test.describe('dontReuseGlobalSetup', () => {
+test.describe('dontReuseGlobalSetup', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/32121' } }, () => {
   test.skip(({ overridePlaywrightVersion }) => !!overridePlaywrightVersion, 'old world doesnt have globalSetup');
 
   function expectOrdering(log: string, items: string[]) {

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1246,3 +1246,60 @@ test('should force workers=1 when reusing the browser', async ({ activate, showB
   const testRun = await testController.run();
   expect(testRun.renderLog({ output: true })).toContain('Running 3 tests using 1 worker');
 });
+
+test.describe('dontReuseGlobalSetup', () => {
+  test.skip(({ overridePlaywrightVersion }) => !!overridePlaywrightVersion, 'old world doesnt have globalSetup');
+
+  function expectOrdering(log: string, items: string[]) {
+    items.forEach(item => expect(log).toContain(item));
+
+    const indices = items.map(item => log.indexOf(item));
+    expect(indices, `log contains entries ${JSON.stringify(items)} in order`).toEqual(indices.sort());
+  }
+
+  const files = {
+    'playwright.config.js': `module.exports = {
+      testDir: 'tests',
+      globalSetup: './globalSetup.js',
+      globalTeardown: './globalTeardown.js',
+    }`,
+    'globalSetup.js': `
+      export default () => console.log('RUNNING SETUP');
+    `,
+    'globalTeardown.js': `
+      export default () => console.log('RUNNING TEARDOWN');
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {
+        console.log('RUNNING TEST');
+      });
+    `,
+  };
+
+  test('if disabled, should run global setup only once and teardown never automatically', async ({ activate }) => {
+    const { testController } = await activate(files);
+
+    const firstRun = (await testController.run()).renderOutput();
+    expectOrdering(firstRun, ['RUNNING SETUP', 'RUNNING TEST']);
+    expect(firstRun).not.toContain('RUNNING TEARDOWN');
+
+    const secondRun = (await testController.run()).renderOutput();
+    expect(secondRun).toContain('RUNNING TEST');
+    expect(secondRun).not.toContain('RUNNING SETUP');
+    expect(secondRun).not.toContain('RUNNING TEARDOWN');
+  });
+
+  test('should always run global setup and teardown if dontReuseGlobalSetup is enabled', async ({ activate }) => {
+    const { testController } = await activate(files, { dontReuseGlobalSetup: true });
+
+    const firstRun = (await testController.run()).renderOutput();
+    expectOrdering(firstRun, ['RUNNING SETUP', 'RUNNING TEST']);
+    expect(firstRun).not.toContain('RUNNING TEARDOWN');
+
+    const secondRun = (await testController.run()).renderOutput();
+    expectOrdering(secondRun, ['RUNNING TEARDOWN', 'RUNNING SETUP', 'RUNNING TEST']);
+  });
+});
+
+

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -36,7 +36,7 @@ type Latch = {
 
 type TestFixtures = {
   vscode: VSCode,
-  activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, dontReuseGlobalSetup?: boolean }) => Promise<ActivateResult>;
+  activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, runGlobalSetupOnEachRun?: boolean }) => Promise<ActivateResult>;
   createLatch: () => Latch;
 };
 
@@ -132,7 +132,7 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions>({
 
   activate: async ({ vscode, showBrowser, overridePlaywrightVersion, showTrace }, use, testInfo) => {
     const instances: VSCode[] = [];
-    await use(async (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, dontReuseGlobalSetup?: boolean }) => {
+    await use(async (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, runGlobalSetupOnEachRun?: boolean }) => {
       if (options?.workspaceFolders) {
         for (const wf of options?.workspaceFolders)
           await vscode.addWorkspaceFolder(wf[0], wf[1]);
@@ -143,8 +143,8 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions>({
       const configuration = vscode.workspace.getConfiguration('playwright');
       if (options?.env)
         configuration.update('env', options.env);
-      if (options?.dontReuseGlobalSetup)
-        configuration.update('dontReuseGlobalSetup', true);
+      if (options?.runGlobalSetupOnEachRun)
+        configuration.update('runGlobalSetupOnEachRun', true);
       if (showBrowser)
         configuration.update('reuseBrowser', true);
       if (showTrace) {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -36,7 +36,7 @@ type Latch = {
 
 type TestFixtures = {
   vscode: VSCode,
-  activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any> }) => Promise<ActivateResult>;
+  activate: (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, dontReuseGlobalSetup?: boolean }) => Promise<ActivateResult>;
   createLatch: () => Latch;
 };
 
@@ -132,7 +132,7 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions>({
 
   activate: async ({ vscode, showBrowser, overridePlaywrightVersion, showTrace }, use, testInfo) => {
     const instances: VSCode[] = [];
-    await use(async (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any> }) => {
+    await use(async (files: { [key: string]: string }, options?: { rootDir?: string, workspaceFolders?: [string, any][], env?: Record<string, any>, dontReuseGlobalSetup?: boolean }) => {
       if (options?.workspaceFolders) {
         for (const wf of options?.workspaceFolders)
           await vscode.addWorkspaceFolder(wf[0], wf[1]);
@@ -143,6 +143,8 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions>({
       const configuration = vscode.workspace.getConfiguration('playwright');
       if (options?.env)
         configuration.update('env', options.env);
+      if (options?.dontReuseGlobalSetup)
+        configuration.update('dontReuseGlobalSetup', true);
       if (showBrowser)
         configuration.update('reuseBrowser', true);
       if (showTrace) {


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32121.

Adds an opt-in checkbox called "Don't reuse global setup". When enabled, we'll re-run global setup before every test run.