### PR TITLE
fix: stop global setup when debugger is terminated

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -533,7 +533,10 @@ export class Extension implements RunHooks {
     };
 
     if (mode === 'debug') {
-      await model.debugTests(items, testListener, testRun.token);
+      const debugEnd = new this._vscode.CancellationTokenSource();
+      testRun.token.onCancellationRequested(() => debugEnd.cancel());
+      this._vscode.debug.onDidTerminateDebugSession(() => debugEnd.cancel());
+      await model.debugTests(items, testListener, debugEnd.token);
     } else {
       // Force trace viewer update to surface check version errors.
       await this._models.selectedModel()?.updateTraceViewer(mode === 'run')?.willRunTests();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -352,7 +352,7 @@ export class Extension implements RunHooks {
     const testRun = this._testController.createTestRun(request);
     const testListener = this._errorReportingListener(testRun);
     try {
-      const status = (await this._models.selectedModel()?.runGlobalHooks(type, testListener)) || 'failed';
+      const status = (await this._models.selectedModel()?.runGlobalHooks(type, testListener, testRun.token)) || 'failed';
       return status;
     } finally {
       testRun.end();

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -255,10 +255,11 @@ export class PlaywrightTestServer {
       if (!locations && !testIds)
         return;
 
-      const result = await this._runGlobalHooksInServer(debugTestServer, 'setup', reporter);
+      const result = await Promise.race([
+        this._runGlobalHooksInServer(debugTestServer, 'setup', reporter),
+        new Promise<'cancellationRequested'>(f => token.onCancellationRequested(() => f('cancellationRequested'))),
+      ]);
       if (result !== 'passed')
-        return;
-      if (token?.isCancellationRequested)
         return;
 
       // Locations are regular expressions.

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -462,13 +462,13 @@ export class TestModel extends DisposableBase {
     return false;
   }
 
-  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2): Promise<reporterTypes.FullResult['status']> {
+  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken): Promise<reporterTypes.FullResult['status']> {
     if (!this.canRunGlobalHooks(type))
       return 'passed';
     if (type === 'setup') {
       if (this._ranGlobalSetup)
         return 'passed';
-      const status = await this._playwrightTest.runGlobalHooks('setup', testListener);
+      const status = await this._playwrightTest.runGlobalHooks('setup', testListener, token);
       if (status === 'passed')
         this._ranGlobalSetup = true;
       return status;
@@ -476,7 +476,7 @@ export class TestModel extends DisposableBase {
 
     if (!this._ranGlobalSetup)
       return 'passed';
-    const status = await this._playwrightTest.runGlobalHooks('teardown', testListener);
+    const status = await this._playwrightTest.runGlobalHooks('teardown', testListener, token);
     this._ranGlobalSetup = false;
     return status;
   }

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -524,7 +524,7 @@ export class TestModel extends DisposableBase {
     // Run global setup with the first test.
     let globalSetupResult: reporterTypes.FullResult['status'] = 'passed';
     if (this.canRunGlobalHooks('setup'))
-      globalSetupResult = await this.runGlobalHooks('setup', reporter);
+      globalSetupResult = await this.runGlobalHooks('setup', reporter, token);
     if (globalSetupResult !== 'passed')
       return;
 
@@ -568,7 +568,7 @@ export class TestModel extends DisposableBase {
       return;
 
     // Underlying debugTest implementation will run the global setup.
-    await this.runGlobalHooks('teardown', reporter);
+    await this.runGlobalHooks('teardown', reporter, token);
     if (token?.isCancellationRequested)
       return;
 

--- a/tests/debug-tests.spec.ts
+++ b/tests/debug-tests.spec.ts
@@ -209,9 +209,8 @@ test('should end test run when stopping the debugging during config parsing', as
   const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
   profile.run(testItems);
   const testRun = await testRunPromise;
-  await expect.poll(() => vscode.debug.output).toContain('READY TO BREAK');
-
   const endPromise = new Promise(f => testRun.onDidEnd(f));
+  await expect.poll(() => vscode.debug.output).toContain('READY TO BREAK');
   vscode.debug.stopDebugging();
   await endPromise;
 


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32387

We're using the cancellation token passed by VS Code to abort an ongoing debug run. There's two problems with this:

1. VS Code doesn't cancel the token if the debugger is terminated
1. If the debugger terminates during `runGlobalSetup`, the underlying process will go away and stall `runGlobalSetup`.

This PR fixes both by adding the debugger termination onto the cancellation token and racing `runGlobalSetup` against it.