### PR TITLE
fix(windows): create Project via PowerShell Terminal

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -67,7 +67,11 @@ export async function installPlaywright(vscode: vscodeTypes.VSCode) {
   if (result.includes(installDepsItem))
     args.push('--install-deps');
 
-  terminal.sendText(`npm init playwright@latest --yes -- --quiet ${args.join(' ')}`, true);
+  terminal.sendText(`npm init playwright@latest --yes ${quote('--')} ${quote('--quiet')} ${args.map(quote).join(' ')}`, true);
+}
+
+function quote(s: string): string {
+  return `'${s}'`;
 }
 
 export async function installBrowsers(vscode: vscodeTypes.VSCode, model: TestModel) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/32400

This will end up in an unused `--` when using Command Prompt. When using PowerShell, PowerShell will filter out the `--` and it will remove the quotes in both cases before sending it to NPM.