### PR TITLE
chore: bump @playwright/test to 1.47 beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.23.2",
-        "@playwright/test": "^1.47.0-alpha-2024-08-17",
+        "@playwright/test": "1.47.0-beta-1725531189000",
         "@types/babel__core": "^7.20.3",
         "@types/babel__helper-plugin-utils": "^7.10.2",
         "@types/babel__traverse": "^7.20.3",
@@ -1080,12 +1080,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.47.0-alpha-2024-08-17",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0-alpha-2024-08-17.tgz",
-      "integrity": "sha512-p7lsSzkLMsvSf1SjAvD4hbqND44alnSJOaj5kMx0pOOfb+SlREZosAMXkq8hfB6NgsVYOOm6QJJLuEpNN0W7HQ==",
+      "version": "1.47.0-beta-1725531189000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0-beta-1725531189000.tgz",
+      "integrity": "sha512-vIXLYI725qen6gbrkiD+KphLnjHEHumK7lv6BYP4ZTzbI48Cc7eKkysrLIP1EajghejmPa0DCwsrQmMEElM1mQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.47.0-alpha-2024-08-17"
+        "playwright": "1.47.0-beta-1725531189000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3449,6 +3450,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4644,12 +4646,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.47.0-alpha-2024-08-17",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0-alpha-2024-08-17.tgz",
-      "integrity": "sha512-c+c8zOtvPiB9iHEgE71kT9bgDPeXzExWqJZHHKUtR+BNamQnQkyiPqZ3YpovQ6qQX4SQ+TUOsfBKXB2VjnCu1g==",
+      "version": "1.47.0-beta-1725531189000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0-beta-1725531189000.tgz",
+      "integrity": "sha512-OkqvMHZOGrXL0xR8qUb0sY4/VK0CElbgJjC2pMVo77zxfOaBjzWVT3Zq5+zeoAOc+LUTWrG8YJNpRIlLoiDZlg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.47.0-alpha-2024-08-17"
+        "playwright-core": "1.47.0-beta-1725531189000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4662,10 +4665,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.47.0-alpha-2024-08-17",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0-alpha-2024-08-17.tgz",
-      "integrity": "sha512-nJyT85MFVbPLCs1lFvuxKNsLxykx7kqHYuF/Zzt8umgeb+Q/ju9jXvJkYFiiZyL4hUAKB3X3gcPgYmJKRb/RDQ==",
+      "version": "1.47.0-beta-1725531189000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0-beta-1725531189000.tgz",
+      "integrity": "sha512-a3jiPt5nHo14i/4is7diMKiq+e0Tc/UNjiVy7fHH1gfPw9kHQMAgWuoOYwMAawFNFOyYuZSk4KNBTRfVgtMkVw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -6413,12 +6417,12 @@
       "optional": true
     },
     "@playwright/test": {
-      "version": "1.47.0-alpha-2024-08-17",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0-alpha-2024-08-17.tgz",
-      "integrity": "sha512-p7lsSzkLMsvSf1SjAvD4hbqND44alnSJOaj5kMx0pOOfb+SlREZosAMXkq8hfB6NgsVYOOm6QJJLuEpNN0W7HQ==",
+      "version": "1.47.0-beta-1725531189000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0-beta-1725531189000.tgz",
+      "integrity": "sha512-vIXLYI725qen6gbrkiD+KphLnjHEHumK7lv6BYP4ZTzbI48Cc7eKkysrLIP1EajghejmPa0DCwsrQmMEElM1mQ==",
       "dev": true,
       "requires": {
-        "playwright": "1.47.0-alpha-2024-08-17"
+        "playwright": "1.47.0-beta-1725531189000"
       }
     },
     "@types/babel__core": {
@@ -8871,19 +8875,19 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.47.0-alpha-2024-08-17",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0-alpha-2024-08-17.tgz",
-      "integrity": "sha512-c+c8zOtvPiB9iHEgE71kT9bgDPeXzExWqJZHHKUtR+BNamQnQkyiPqZ3YpovQ6qQX4SQ+TUOsfBKXB2VjnCu1g==",
+      "version": "1.47.0-beta-1725531189000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0-beta-1725531189000.tgz",
+      "integrity": "sha512-OkqvMHZOGrXL0xR8qUb0sY4/VK0CElbgJjC2pMVo77zxfOaBjzWVT3Zq5+zeoAOc+LUTWrG8YJNpRIlLoiDZlg==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.47.0-alpha-2024-08-17"
+        "playwright-core": "1.47.0-beta-1725531189000"
       }
     },
     "playwright-core": {
-      "version": "1.47.0-alpha-2024-08-17",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0-alpha-2024-08-17.tgz",
-      "integrity": "sha512-nJyT85MFVbPLCs1lFvuxKNsLxykx7kqHYuF/Zzt8umgeb+Q/ju9jXvJkYFiiZyL4hUAKB3X3gcPgYmJKRb/RDQ==",
+      "version": "1.47.0-beta-1725531189000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0-beta-1725531189000.tgz",
+      "integrity": "sha512-a3jiPt5nHo14i/4is7diMKiq+e0Tc/UNjiVy7fHH1gfPw9kHQMAgWuoOYwMAawFNFOyYuZSk4KNBTRfVgtMkVw==",
       "dev": true
     },
     "prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.2",
-    "@playwright/test": "^1.47.0-alpha-2024-08-17",
+    "@playwright/test": "1.47.0-beta-1725531189000",
     "@types/babel__core": "^7.20.3",
     "@types/babel__helper-plugin-utils": "^7.10.2",
     "@types/babel__traverse": "^7.20.3",


### PR DESCRIPTION
This one already was on 1.47-alpha because of https://github.com/microsoft/playwright-vscode/pull/517
