### PR TITLE
Revert "fix: stop global setup when debugger is terminated (#525)"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -353,7 +353,7 @@ export class Extension implements RunHooks {
     const testRun = this._testController.createTestRun(request);
     const testListener = this._errorReportingListener(testRun);
     try {
-      const status = (await this._models.selectedModel()?.runGlobalHooks(type, testListener, testRun.token)) || 'failed';
+      const status = (await this._models.selectedModel()?.runGlobalHooks(type, testListener)) || 'failed';
       return status;
     } finally {
       testRun.end();
@@ -534,10 +534,7 @@ export class Extension implements RunHooks {
     };
 
     if (mode === 'debug') {
-      const debugEnd = new this._vscode.CancellationTokenSource();
-      testRun.token.onCancellationRequested(() => debugEnd.cancel());
-      this._vscode.debug.onDidTerminateDebugSession(() => debugEnd.cancel());
-      await model.debugTests(items, testListener, debugEnd.token);
+      await model.debugTests(items, testListener, testRun.token);
     } else {
       // Force trace viewer update to surface check version errors.
       await this._models.selectedModel()?.updateTraceViewer(mode === 'run')?.willRunTests();

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -470,13 +470,13 @@ export class TestModel extends DisposableBase {
     return false;
   }
 
-  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken): Promise<reporterTypes.FullResult['status']> {
+  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2): Promise<reporterTypes.FullResult['status']> {
     if (!this.canRunGlobalHooks(type))
       return 'passed';
     if (type === 'setup') {
       if (!this.canRunGlobalHooks('setup'))
         return 'passed';
-      const status = await this._playwrightTest.runGlobalHooks('setup', testListener, token);
+      const status = await this._playwrightTest.runGlobalHooks('setup', testListener);
       if (status === 'passed')
         this._ranGlobalSetup = true;
       return status;
@@ -484,7 +484,7 @@ export class TestModel extends DisposableBase {
 
     if (!this._ranGlobalSetup)
       return 'passed';
-    const status = await this._playwrightTest.runGlobalHooks('teardown', testListener, token);
+    const status = await this._playwrightTest.runGlobalHooks('teardown', testListener);
     this._ranGlobalSetup = false;
     return status;
   }
@@ -524,7 +524,7 @@ export class TestModel extends DisposableBase {
     // Run global setup with the first test.
     let globalSetupResult: reporterTypes.FullResult['status'] = 'passed';
     if (this.canRunGlobalHooks('setup'))
-      globalSetupResult = await this.runGlobalHooks('setup', reporter, token);
+      globalSetupResult = await this.runGlobalHooks('setup', reporter);
     if (globalSetupResult !== 'passed')
       return;
 
@@ -568,7 +568,7 @@ export class TestModel extends DisposableBase {
       return;
 
     // Underlying debugTest implementation will run the global setup.
-    await this.runGlobalHooks('teardown', reporter, token);
+    await this.runGlobalHooks('teardown', reporter);
     if (token?.isCancellationRequested)
       return;
 

--- a/tests/debug-tests.spec.ts
+++ b/tests/debug-tests.spec.ts
@@ -180,48 +180,6 @@ test('should end test run when stopping the debugging', async ({ activate }, tes
   testRun.token.source.cancel();
 });
 
-test('should end test run when stopping the debugging during config parsing', async ({ activate }) => {
-  const { vscode, testController } = await activate({
-    'package.json': JSON.stringify({ type: 'module' }),
-    'playwright.config.js': `
-      // Simulate breakpoint via stalling.
-      async function stall() {
-        console.log('READY TO BREAK');
-        await new Promise(() => {});
-      }
-      
-      process.env.STALL_CONFIG === '1' && await stall();
-      export default { testDir: 'tests' }
-    `,
-    'tests/test.spec.ts': `
-      import { test } from '@playwright/test';
-      test('should fail', async () => {});
-    `,
-  }, { env: { STALL_CONFIG: '0' } });
-
-  await testController.expandTestItems(/test.spec/);
-  const testItems = testController.findTestItems(/fail/);
-
-  const configuration = vscode.workspace.getConfiguration('playwright');
-  configuration.update('env', { STALL_CONFIG: '1' });
-
-  const profile = testController.debugProfile();
-  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
-  profile.run(testItems);
-  const testRun = await testRunPromise;
-  const endPromise = new Promise(f => testRun.onDidEnd(f));
-  await expect.poll(() => vscode.debug.output).toContain('READY TO BREAK');
-  vscode.debug.stopDebugging();
-  await endPromise;
-
-  expect(testRun.renderLog({ messages: true })).toBe(`
-    tests > test.spec.ts > should fail [2:0]
-      enqueued
-  `);
-
-  testRun.token.source.cancel();
-});
-
 test('should pass all args as string[] when debugging', async ({ activate }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30829' });
   const { vscode, testController } = await activate({


### PR DESCRIPTION
This reverts commit 4328be9555ecfe8a241e1ed3480e5e2b1866c9cf.

Relates https://github.com/microsoft/playwright/issues/32710