### PR TITLE
fix: stop global setup when debugger is terminated attempt #2

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -538,7 +538,10 @@ export class Extension implements RunHooks {
       testRun.token.onCancellationRequested(() => debugEnd.cancel());
 
       let mainDebugRun: vscodeTypes.DebugSession | undefined;
-      this._vscode.debug.onDidStartDebugSession(session => { mainDebugRun ??= session; });
+      this._vscode.debug.onDidStartDebugSession(session => {
+        if (session.name === 'Playwright Test')
+          mainDebugRun ??= session;
+      });
       this._vscode.debug.onDidTerminateDebugSession(session => {
         // child processes have their own debug sessions,
         // but we only want to stop debugging if the user cancels the main session

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -534,22 +534,7 @@ export class Extension implements RunHooks {
     };
 
     if (mode === 'debug') {
-      const debugEnd = new this._vscode.CancellationTokenSource();
-      testRun.token.onCancellationRequested(() => debugEnd.cancel());
-
-      let mainDebugRun: vscodeTypes.DebugSession | undefined;
-      this._vscode.debug.onDidStartDebugSession(session => {
-        if (session.name === 'Playwright Test')
-          mainDebugRun ??= session;
-      });
-      this._vscode.debug.onDidTerminateDebugSession(session => {
-        // child processes have their own debug sessions,
-        // but we only want to stop debugging if the user cancels the main session
-        if (session.id === mainDebugRun?.id)
-          debugEnd.cancel();
-      });
-
-      await model.debugTests(items, testListener, debugEnd.token);
+      await model.debugTests(items, testListener, testRun.token);
     } else {
       // Force trace viewer update to surface check version errors.
       await this._models.selectedModel()?.updateTraceViewer(mode === 'run')?.willRunTests();

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -107,14 +107,14 @@ export class PlaywrightTestServer {
       teleReceiver.dispatch(message);
   }
 
-  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2): Promise<'passed' | 'failed' | 'interrupted' | 'timedout'> {
+  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken): Promise<'passed' | 'failed' | 'interrupted' | 'timedout'> {
     const testServer = await this._testServer();
     if (!testServer)
       return 'failed';
-    return await this._runGlobalHooksInServer(testServer, type, testListener);
+    return await this._runGlobalHooksInServer(testServer, type, testListener, token);
   }
 
-  private async _runGlobalHooksInServer(testServer: TestServerConnection, type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2): Promise<'passed' | 'failed' | 'interrupted' | 'timedout'> {
+  private async _runGlobalHooksInServer(testServer: TestServerConnection, type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken): Promise<'passed' | 'failed' | 'interrupted' | 'timedout'> {
     const teleReceiver = new TeleReporterReceiver(testListener, {
       mergeProjects: true,
       mergeTestCases: true,
@@ -130,12 +130,18 @@ export class PlaywrightTestServer {
     try {
       if (type === 'setup') {
         testListener.onStdOut?.('\x1b[2mRunning global setup if any\u2026\x1b[0m\n');
-        const { report, status } = await testServer.runGlobalSetup({});
+        const { report, status } = await Promise.race([
+          testServer.runGlobalSetup({}),
+          new Promise<{ status: 'interrupted', report: [] }>(f => token.onCancellationRequested(() => f({ status: 'interrupted', report: [] }))),
+        ]);
         for (const message of report)
           teleReceiver.dispatch(message);
         return status;
       }
-      const { report, status } = await testServer.runGlobalTeardown({});
+      const { report, status } = await Promise.race([
+        testServer.runGlobalTeardown({}),
+        new Promise<{ status: 'interrupted', report: [] }>(f => token.onCancellationRequested(() => f({ status: 'interrupted', report: [] }))),
+      ]);
       for (const message of report)
         teleReceiver.dispatch(message);
       return status;
@@ -218,7 +224,7 @@ export class PlaywrightTestServer {
     const testDirs = this._model.enabledProjects().map(project => project.project.testDir);
 
     let debugTestServer: TestServerConnection | undefined;
-    let disposable: vscodeTypes.Disposable | undefined;
+    const disposables: vscodeTypes.Disposable[] = [];
     try {
       await this._vscode.debug.startDebugging(undefined, {
         type: 'pwa-node',
@@ -255,10 +261,8 @@ export class PlaywrightTestServer {
       if (!locations && !testIds)
         return;
 
-      const result = await this._runGlobalHooksInServer(debugTestServer, 'setup', reporter);
+      const result = await this._runGlobalHooksInServer(debugTestServer, 'setup', reporter, token);
       if (result !== 'passed')
-        return;
-      if (token?.isCancellationRequested)
         return;
 
       // Locations are regular expressions.
@@ -271,21 +275,21 @@ export class PlaywrightTestServer {
       };
       debugTestServer.runTests(options);
 
-      token.onCancellationRequested(() => {
+      disposables.push(token.onCancellationRequested(() => {
         debugTestServer!.stopTestsNoReply({});
-      });
-      disposable = debugTestServer.onStdio(params => {
+      }));
+      disposables.push(debugTestServer.onStdio(params => {
         if (params.type === 'stdout')
           reporter.onStdOut?.(unwrapString(params));
         if (params.type === 'stderr')
           reporter.onStdErr?.(unwrapString(params));
-      });
+      }));
       const testEndPromise = this._wireTestServer(debugTestServer, reporter, token);
       await testEndPromise;
     } finally {
-      disposable?.dispose();
+      disposables.forEach(disposable => disposable.dispose());
       if (!token.isCancellationRequested && debugTestServer && !debugTestServer.isClosed())
-        await this._runGlobalHooksInServer(debugTestServer, 'teardown', reporter);
+        await this._runGlobalHooksInServer(debugTestServer, 'teardown', reporter, token);
       debugTestServer?.close();
       await this._options.runHooks.onDidRunTests(true);
     }

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -231,7 +231,7 @@ export class PlaywrightTestServer {
 
       let mainDebugRun: vscodeTypes.DebugSession | undefined;
       this._vscode.debug.onDidStartDebugSession(session => {
-        if (session.name === 'Playwright Test')
+        if (session.name === debugSessionName)
           mainDebugRun ??= session;
       });
       this._vscode.debug.onDidTerminateDebugSession(session => {

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -470,13 +470,13 @@ export class TestModel extends DisposableBase {
     return false;
   }
 
-  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2): Promise<reporterTypes.FullResult['status']> {
+  async runGlobalHooks(type: 'setup' | 'teardown', testListener: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken): Promise<reporterTypes.FullResult['status']> {
     if (!this.canRunGlobalHooks(type))
       return 'passed';
     if (type === 'setup') {
       if (!this.canRunGlobalHooks('setup'))
         return 'passed';
-      const status = await this._playwrightTest.runGlobalHooks('setup', testListener);
+      const status = await this._playwrightTest.runGlobalHooks('setup', testListener, token);
       if (status === 'passed')
         this._ranGlobalSetup = true;
       return status;
@@ -484,7 +484,7 @@ export class TestModel extends DisposableBase {
 
     if (!this._ranGlobalSetup)
       return 'passed';
-    const status = await this._playwrightTest.runGlobalHooks('teardown', testListener);
+    const status = await this._playwrightTest.runGlobalHooks('teardown', testListener, token);
     this._ranGlobalSetup = false;
     return status;
   }
@@ -524,7 +524,7 @@ export class TestModel extends DisposableBase {
     // Run global setup with the first test.
     let globalSetupResult: reporterTypes.FullResult['status'] = 'passed';
     if (this.canRunGlobalHooks('setup'))
-      globalSetupResult = await this.runGlobalHooks('setup', reporter);
+      globalSetupResult = await this.runGlobalHooks('setup', reporter, token);
     if (globalSetupResult !== 'passed')
       return;
 
@@ -568,7 +568,7 @@ export class TestModel extends DisposableBase {
       return;
 
     // Underlying debugTest implementation will run the global setup.
-    await this.runGlobalHooks('teardown', reporter);
+    await this.runGlobalHooks('teardown', reporter, token);
     if (token?.isCancellationRequested)
       return;
 

--- a/tests/debug-tests.spec.ts
+++ b/tests/debug-tests.spec.ts
@@ -180,6 +180,48 @@ test('should end test run when stopping the debugging', async ({ activate }, tes
   testRun.token.source.cancel();
 });
 
+test('should end test run when stopping the debugging during config parsing', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'package.json': JSON.stringify({ type: 'module' }),
+    'playwright.config.js': `
+      // Simulate breakpoint via stalling.
+      async function stall() {
+        console.log('READY TO BREAK');
+        await new Promise(() => {});
+      }
+      
+      process.env.STALL_CONFIG === '1' && await stall();
+      export default { testDir: 'tests' }
+    `,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should fail', async () => {});
+    `,
+  }, { env: { STALL_CONFIG: '0' } });
+
+  await testController.expandTestItems(/test.spec/);
+  const testItems = testController.findTestItems(/fail/);
+
+  const configuration = vscode.workspace.getConfiguration('playwright');
+  configuration.update('env', { STALL_CONFIG: '1' });
+
+  const profile = testController.debugProfile();
+  const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
+  profile.run(testItems);
+  const testRun = await testRunPromise;
+  const endPromise = new Promise(f => testRun.onDidEnd(f));
+  await expect.poll(() => vscode.debug.output).toContain('READY TO BREAK');
+  vscode.debug.stopDebugging();
+  await endPromise;
+
+  expect(testRun.renderLog({ messages: true })).toBe(`
+    tests > test.spec.ts > should fail [2:0]
+      enqueued
+  `);
+
+  testRun.token.source.cancel();
+});
+
 test('should pass all args as string[] when debugging', async ({ activate }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30829' });
   const { vscode, testController } = await activate({


### PR DESCRIPTION
Second attempt at #525, which got reverted.

The problem was that we were stopping everything as soon as the first debug session stops. It turns out that there's more than one debug session though! The child process that's used to evaluate `playwright.config.ts` gets its own child debug session. Once it successfully closes, the `onDidTerminateDebugSession` handler is executed. In the past attempt, this closed debugging.

The fix is to only call `debugEnd.cancel()` if the main debug session is closed.

Closes https://github.com/microsoft/playwright/issues/32387