### PR TITLE
fix: pass relative config path to test-server for running

### DIFF
--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -316,10 +316,15 @@ export class PlaywrightTestServer {
   }
 
   private async _createTestServer(): Promise<TestServerConnection | null> {
-    const args = [this._model.config.cli, 'test-server', '-c', this._configPath()];
+    const cwd = this._model.config.workspaceFolder;
+    const args = [
+      path.relative(cwd, this._model.config.cli),
+      'test-server',
+      '-c', this._configPath()
+    ];
     const wsEndpoint = await startBackend(this._vscode, {
       args,
-      cwd: this._model.config.workspaceFolder,
+      cwd,
       envProvider: () => {
         return {
           ...this._options.envProvider(),

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -199,11 +199,14 @@ export class PlaywrightTestServer {
     disposable.dispose();
   }
 
-  async debugTests(items: vscodeTypes.TestItem[], runOptions: PlaywrightTestRunOptions, reporter: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken): Promise<void> {
+  private _configPath() {
     // Important, VSCode will change c:\\ to C:\\ in the program argument.
     // This forks globals into 2 worlds, hence we specify it relative than absolute.
-    const configFile = path.relative(this._model.config.workspaceFolder, this._model.config.configFile);
-    const args = ['test-server', '-c', configFile];
+    return path.relative(this._model.config.workspaceFolder, this._model.config.configFile);
+  }
+
+  async debugTests(items: vscodeTypes.TestItem[], runOptions: PlaywrightTestRunOptions, reporter: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken): Promise<void> {
+    const args = ['test-server', '-c', this._configPath()];
 
     const addressPromise = new Promise<string>(f => {
       const disposable = this._options.onStdOut(output => {
@@ -313,7 +316,7 @@ export class PlaywrightTestServer {
   }
 
   private async _createTestServer(): Promise<TestServerConnection | null> {
-    const args = [this._model.config.cli, 'test-server', '-c', this._model.config.configFile];
+    const args = [this._model.config.cli, 'test-server', '-c', this._configPath()];
     const wsEndpoint = await startBackend(this._vscode, {
       args,
       cwd: this._model.config.workspaceFolder,

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -648,7 +648,7 @@ export class TestModel extends DisposableBase {
       if (treeItem.kind === 'group' && (treeItem.subKind === 'folder' || treeItem.subKind === 'file')) {
         for (const file of this.enabledFiles()) {
           if (file === treeItem.location.file || file.startsWith(treeItem.location.file))
-            locations.add(treeItem.location.file);
+            locations.add(path.relative(this.config.workspaceFolder, treeItem.location.file));
         }
       } else {
         testIds.push(...collectTestIds(treeItem));

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -648,7 +648,7 @@ export class TestModel extends DisposableBase {
       if (treeItem.kind === 'group' && (treeItem.subKind === 'folder' || treeItem.subKind === 'file')) {
         for (const file of this.enabledFiles()) {
           if (file === treeItem.location.file || file.startsWith(treeItem.location.file))
-            locations.add(path.relative(this.config.workspaceFolder, treeItem.location.file));
+            locations.add(treeItem.location.file);
         }
       } else {
         testIds.push(...collectTestIds(treeItem));


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/32959. Similar to the fix we shipped for debugging in #482 and #484.