### PR TITLE
fix: run Electron test

### DIFF
--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -369,6 +369,8 @@ export class PlaywrightTestServer {
         return {
           ...this._options.envProvider(),
           FORCE_COLOR: '1',
+          // Reset VSCode's options that affect nested Electron.
+          ELECTRON_RUN_AS_NODE: undefined,
         };
       },
       dumpIO: false,


### PR DESCRIPTION
This copies the hack from here to the new TestServer wiring:

https://github.com/microsoft/playwright-vscode/blob/fea6cfffcfce869b5193521651ba37af7b00b6e2/src/playwrightTestCLI.ts#L134

Fixes https://github.com/microsoft/playwright/issues/33209