### PR TITLE
chore: mark 1.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "dependencies": {
         "@babel/core": "^7.23.2",
         "@babel/helper-plugin-utils": "^7.22.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Playwright Test for VSCode",
   "description": "%description%",
   "icon": "images/playwright-logo.png",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "publisher": "ms-playwright",
   "repository": "https://github.com/microsoft/playwright-vscode",
   "bugs": {


### PR DESCRIPTION
Release Notes:

- feat: add toggle for always recreating global setup #524
- fix(windows): create Project via PowerShell Terminal (#526)
- allow install command as terminal link provider (#528)
- fix: stop global setup when debugger is terminated (#537)
- chore: ensure disposables are disposed (#522)
- chore: add @babel/plugin-proposal-decorators to babelBundle (#532)
- fix(windows): pass relative config path to test-server for running (#538)
- fix: allow trace in showBrowser mode (#542)