### PR TITLE
chore: render Error.cause

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -742,15 +742,10 @@ export class Extension implements RunHooks {
     return testMessage;
   }
 
-  private _formatError(error: reporterTypes.TestError, tab: string = ''): string {
+  private _formatError(error: reporterTypes.TestError): string {
     const tokens = [error.stack || error.message || error.value || ''];
-    if (error.cause) {
-      tab += '  ';
-      tokens.push(indent('[cause]: ' + this._formatError(error.cause, tab), tab));
-    }
-    function indent(lines: string, tab: string) {
-      return lines.replace(/^(?=.+$)/gm, tab);
-    }
+    if (error.cause)
+      tokens.push('[cause]: ' + this._formatError(error.cause));
     return tokens.join('\n');
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -719,7 +719,7 @@ export class Extension implements RunHooks {
   }
 
   private _testMessageForTestError(error: reporterTypes.TestError, testItem?: vscodeTypes.TestItem): vscodeTypes.TestMessage {
-    const text = error.stack || error.message || error.value!;
+    const text = this._formatError(error);
     let testMessage: vscodeTypes.TestMessage;
     if (text.includes('Looks like Playwright Test or Playwright')) {
       testMessage = this._testMessageFromHtml(`
@@ -740,6 +740,18 @@ export class Extension implements RunHooks {
       testMessage.location = new this._vscode.Location(this._vscode.Uri.file(location.file), position);
     }
     return testMessage;
+  }
+
+  private _formatError(error: reporterTypes.TestError, tab: string = ''): string {
+    const tokens = [error.stack || error.message || error.value || ''];
+    if (error.cause) {
+      tab += '  ';
+      tokens.push(indent('[cause]: ' + this._formatError(error.cause, tab), tab));
+    }
+    function indent(lines: string, tab: string) {
+      return lines.replace(/^(?=.+$)/gm, tab);
+    }
+    return tokens.join('\n');
   }
 
   playwrightTestLog(): string[] {

--- a/src/upstream/reporter.d.ts
+++ b/src/upstream/reporter.d.ts
@@ -696,7 +696,7 @@ export interface TestError {
    * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
    * error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
    */
-  cause?: TestInfoError;
+  cause?: TestError;
 
   /**
    * Error location in the source code.

--- a/src/upstream/reporter.d.ts
+++ b/src/upstream/reporter.d.ts
@@ -692,6 +692,13 @@ export interface Location {
  */
 export interface TestError {
   /**
+   * Error cause. Set when there is a
+   * [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the
+   * error. Will be null if there is no cause or if the cause is not an instance of [Error] (or its subclass).
+   */
+  cause?: TestInfoError;
+
+  /**
    * Error location in the source code.
    */
   location?: Location;


### PR DESCRIPTION
This makes `Error.cause` render in test errors:

<img width="1928" alt="image" src="https://github.com/user-attachments/assets/398e1c96-b401-42dd-bf6f-e93ea6a56272">

When looking at the Test Output tab, they are already getting shown, due to base reporter:

<img width="1380" alt="image" src="https://github.com/user-attachments/assets/f13ee4ae-f787-4e5b-9509-b47ab1db75f2">

https://github.com/microsoft/playwright/issues/26848