### PR TITLE
feature: send enabled projects on wire for global-setup

### DIFF
--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -131,7 +131,7 @@ export class PlaywrightTestServer {
       if (type === 'setup') {
         testListener.onStdOut?.('\x1b[2mRunning global setup if any\u2026\x1b[0m\n');
         const { report, status } = await Promise.race([
-          testServer.runGlobalSetup({}),
+          testServer.runGlobalSetup({ projects: this._model.enabledProjectsFilter() }),
           new Promise<{ status: 'interrupted', report: [] }>(f => token.onCancellationRequested(() => f({ status: 'interrupted', report: [] }))),
         ]);
         for (const message of report)


### PR DESCRIPTION
sends enabled projects across the wire to playwright test server

currently `params` isn't read by the listener, so this shouldn't cause any issues

below is reference code for listener, where params is unused -
https://github.com/microsoft/playwright/blob/ff5f1628dc8dbbb0217554adc3105bff4e0a504c/packages/playwright/src/runner/testServer.ts#L149
