### PR TITLE
fix(legacy): extend path normalisation to legacy CLI integration

### DIFF
--- a/src/playwrightTestCLI.ts
+++ b/src/playwrightTestCLI.ts
@@ -143,8 +143,8 @@ export class PlaywrightTestCLI {
     });
 
     const stdio = childProcess.stdio;
-    stdio[1].on('data', data => console.log(data.toString()) || reporter.onStdOut?.(data));
-    stdio[2].on('data', data => console.log(data.toString()) || reporter.onStdErr?.(data));
+    stdio[1].on('data', data => reporter.onStdOut?.(data));
+    stdio[2].on('data', data => reporter.onStdErr?.(data));
     await reporterServer.wireTestListener(reporter, token);
   }
 

--- a/src/playwrightTestCLI.ts
+++ b/src/playwrightTestCLI.ts
@@ -104,7 +104,7 @@ export class PlaywrightTestCLI {
     const reporterServer = new ReporterServer(this._vscode);
     const paths = normalizePaths(this._model.config);
     const node = await findNode(this._vscode, paths.cwd);
-    const configFolder = path.dirname(paths.config);
+    const configFolder = path.dirname(path.resolve(paths.cwd, paths.config));
     const configFile = path.basename(paths.config);
     const escapedLocations = locations.map(escapeRegex).sort();
 
@@ -143,8 +143,8 @@ export class PlaywrightTestCLI {
     });
 
     const stdio = childProcess.stdio;
-    stdio[1].on('data', data => reporter.onStdOut?.(data));
-    stdio[2].on('data', data => reporter.onStdErr?.(data));
+    stdio[1].on('data', data => console.log(data.toString()) || reporter.onStdOut?.(data));
+    stdio[2].on('data', data => console.log(data.toString()) || reporter.onStdErr?.(data));
     await reporterServer.wireTestListener(reporter, token);
   }
 


### PR DESCRIPTION
Extends https://github.com/microsoft/playwright-vscode/pull/538 to the CLI integration, as per https://github.com/microsoft/playwright-vscode/pull/538#discussion_r1794844011.