### PR TITLE
feat(watch): batch watch runs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -345,7 +345,7 @@ export class Extension implements RunHooks {
 
   private async _queueWatchRun(include: readonly vscodeTypes.TestItem[], key: 'files' | 'items') {
     if (key in this._watchRunBatches) {
-      this._watchRunBatches[key].push(...include);
+      this._watchRunBatches[key].push(...include); // `narrowDownLocations` dedupes before sending to the testserver, no need to dedupe here
       return;
     }
 

--- a/tests/watch.spec.ts
+++ b/tests/watch.spec.ts
@@ -473,8 +473,6 @@ test('should batch watched tests, not queue', async ({ activate }, testInfo) => 
   // wait for another run to be done, so we know the queue is empty
   await testController.run(testController.findTestItems(/watched/));
 
-  console.log(queuedTestRuns.map(r => r.renderOutput()));
-
   // one batched run for all changes plus the one above
   expect(queuedTestRuns.length).toBe(2);
 });

--- a/tests/watch.spec.ts
+++ b/tests/watch.spec.ts
@@ -411,6 +411,9 @@ test('should watch two tests in a file', async ({ activate }) => {
 });
 
 test('should batch watched tests, not queue', async ({ activate }, testInfo) => {
+  if (process.platform === 'win32')
+    test.slow();
+
   const semaphore = testInfo.outputPath('semaphore.txt');
   const { testController, workspaceFolder } = await activate({
     'playwright.config.js': `module.exports = { testDir: 'tests' }`,


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/33443.

When running a long test, or a test that times out, every file change leads to another "watch" run being enqueued. They all pile up in the command queue, and once blocking test finishes, they are all executed one-by-one. If the watched runs are all about the same file, then we'll see the same test being executed multiple times, once for each <kbd>⌘+S</kbd>. This is wasteful.

This PR fixes this by batching together all watched runs. We can't run watched files and watched IDs in the same test, so there's separate batches.