### PR TITLE
chore(watch): resolve changed files into test IDs

### DIFF
--- a/tests/watch.spec.ts
+++ b/tests/watch.spec.ts
@@ -81,8 +81,7 @@ test('should watch all tests', async ({ activate }) => {
     {
       method: 'runTests',
       params: expect.objectContaining({
-        locations: [expect.stringContaining(`tests${escapedPathSep}test-1\\.spec\\.ts`)],
-        testIds: undefined
+        testIds: [expect.any(String)]
       })
     },
   ]);
@@ -248,8 +247,7 @@ test('should watch tests via helper', async ({ activate }) => {
     {
       method: 'runTests',
       params: expect.objectContaining({
-        locations: [expect.stringContaining(`tests${escapedPathSep}test\\.spec\\.ts`)],
-        testIds: undefined
+        testIds: [expect.any(String)]
       })
     },
   ]);


### PR DESCRIPTION
This PR changes how we specify which tests to run in watch mode. Before, we had one run for changes to watched files, and a separate one for changes to watched tests. One passed `locations`, one passed `testIDs`. This PR makes us resolve files into test IDs, and use a single run that only specifies `testIDs`. This moves the extension closer in line with what the UI or watch mode do.