### PR TITLE
chore: bump MicroBuildSigningPlugin to v4

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -34,7 +34,7 @@ extends:
           inputs:
             version: '20.x'
           displayName: 'Install Node.js'
-        - task: MicroBuildSigningPlugin@3
+        - task: MicroBuildSigningPlugin@4
           inputs:
             signType: real
             feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'


### PR DESCRIPTION
The old one was Node.js 10 based.