### PR TITLE
fix: node path detection for lazy loading

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,9 @@ async function findNodeViaShell(vscode: vscodeTypes.VSCode, cwd: string): Promis
   return new Promise<string | undefined>(resolve => {
     const startToken = '___START_PW_SHELL__';
     const endToken = '___END_PW_SHELL__';
-    const childProcess = spawn(`${vscode.env.shell} -i -c 'echo ${startToken} && which node && echo ${endToken}'`, {
+    // NVM lazily loads Node.js when 'node' alias is invoked. In order to invoke it, we run 'node --version' if 'node' is a function.
+    // See https://github.com/microsoft/playwright/issues/33996
+    const childProcess = spawn(`${vscode.env.shell} -i -c 'if type node 2>/dev/null | grep -q "function"; then node --version; fi; echo ${startToken} && which node && echo ${endToken}'`, {
       stdio: 'pipe',
       shell: true,
       cwd,


### PR DESCRIPTION
close: https://github.com/microsoft/playwright/issues/33996

NVM lazy loading use cases such as the Oh My Zsh `nvm` plugin might make node a function which will be executed to set the node path when it is run, so executed the `node` command if it is a function to make it point to the real Node binary.