### PR TITLE
chore: use bash builtin string matching instead of calling grep

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,7 @@ async function findNodeViaShell(vscode: vscodeTypes.VSCode, cwd: string): Promis
     const endToken = '___END_PW_SHELL__';
     // NVM lazily loads Node.js when 'node' alias is invoked. In order to invoke it, we run 'node --version' if 'node' is a function.
     // See https://github.com/microsoft/playwright/issues/33996
-    const childProcess = spawn(`${vscode.env.shell} -i -c 'if type node 2>/dev/null | grep -q "function"; then node --version; fi; echo ${startToken} && which node && echo ${endToken}'`, {
+    const childProcess = spawn(`${vscode.env.shell} -i -c 'if [[ $(type node 2>/dev/null) == *function* ]]; then node --version; fi; echo ${startToken} && which node && echo ${endToken}'`, {
       stdio: 'pipe',
       shell: true,
       cwd,


### PR DESCRIPTION
This is a follow-up to https://github.com/microsoft/playwright-vscode/pull/573 which avoids calling `grep` executable and uses shell string matching instead.

Reference https://github.com/microsoft/playwright/issues/33996