### PR TITLE
chore: mark workspace with last activation date

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { registerTerminalLinkProvider } from './terminalLinkProvider';
 import { RunHooks, TestConfig } from './playwrightTestTypes';
 import { ansi2html } from './ansi2html';
 import { LocatorsView } from './locatorsView';
+import { Migrator } from './migrator';
 
 const stackUtils = new StackUtils({
   cwd: '/ensure_absolute_paths'
@@ -50,6 +51,7 @@ export async function activate(context: vscodeTypes.ExtensionContext) {
 export class Extension implements RunHooks {
   private _vscode: vscodeTypes.VSCode;
   private _context: vscodeTypes.ExtensionContext;
+  private _migrator: Migrator;
   private _disposables: vscodeTypes.Disposable[] = [];
 
   // Global test item map.
@@ -84,6 +86,7 @@ export class Extension implements RunHooks {
   constructor(vscode: vscodeTypes.VSCode, context: vscodeTypes.ExtensionContext) {
     this._vscode = vscode;
     this._context = context;
+    this._migrator = new Migrator(context);
     this._isUnderTest = !!(this._vscode as any).isUnderTest;
     this._activeStepDecorationType = this._vscode.window.createTextEditorDecorationType({
       isWholeLine: true,
@@ -149,6 +152,8 @@ export class Extension implements RunHooks {
   }
 
   async activate() {
+    await this._migrator.migrate();
+
     const vscode = this._vscode;
     this._settingsView = new SettingsView(vscode, this._settingsModel, this._models, this._reusedBrowser, this._context.extensionUri);
     this._locatorsView = new LocatorsView(vscode, this._reusedBrowser, this._context.extensionUri);

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as vscodeTypes from './vscodeTypes';
+import * as pack from '../package.json';
+
+const workspaceVersionKey = 'pw.workspace-version';
+interface WorkspaceVersionState {
+  version: string;
+  lastMigrationTime: number;
+  lastMigration: number;
+}
+
+export class Migrator {
+  constructor(private readonly context: vscodeTypes.ExtensionContext) {}
+
+  async migrate() {
+    const state = this.context.workspaceState.get<WorkspaceVersionState>(workspaceVersionKey) ?? { version: '0.0.0', lastMigrationTime: 0, lastMigration: -1 };
+    await this.runMigrations(state.lastMigration);
+    await this.context.workspaceState.update(workspaceVersionKey, { version: pack.version, lastMigrationTime: Date.now(), lastMigration: this.migrations.length - 1 });
+  }
+
+  private migrations: Function[] = [];
+
+  private async runMigrations(lastMigration: number) {
+    for (let i = lastMigration + 1; i < this.migrations.length; ++i)
+      await this.migrations[i]();
+  }
+}

--- a/tests/migrator.spec.ts
+++ b/tests/migrator.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './utils';
+
+const lastMigration = -1;
+
+test('should initialize version info', async ({ vscode, activate }) => {
+  vscode.context.workspaceState.update('pw.workspace-version', undefined);
+  await activate({});
+  expect(vscode.context.workspaceState.get('pw.workspace-version')).toEqual({ version: expect.stringMatching(/\d+\.\d+\.\d+/), lastMigrationTime: expect.any(Number), lastMigration });
+});
+
+test('should update version info', async ({ vscode, activate }) => {
+  vscode.context.workspaceState.update('pw.workspace-version', { version: 'v0.0.0', lastMigrationTime: 0, lastMigration: -1 });
+  await activate({});
+  const versionInfo = vscode.context.workspaceState.get('pw.workspace-version');
+  expect(versionInfo.version).not.toBe('v0.0.0');
+  expect(versionInfo.lastMigrationTime).toBeCloseTo(Date.now(), -4);
+  expect(versionInfo.lastMigration).toBe(lastMigration);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": ".",
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true,
   },
   "include": ["src", "tests"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR adds the skeleton for running any kind of migration. Upon activation, it runs migrations and marks the workspace with the last activation date, activated version and the last executed migration.

It'll allow us to distinguish between existing and new projects, which we'll need to ship https://github.com/microsoft/playwright/issues/33865 to new users without breaking the workflow of existing users.