### PR TITLE
chore: running tests should create workspace-settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,6 +129,7 @@ export class Extension implements RunHooks {
   }
 
   async onWillRunTests(config: TestConfig, debug: boolean) {
+    this._models.onWillRunTests();
     await this._reusedBrowser.onWillRunTests(config, debug);
     return {
       connectWsEndpoint: this._reusedBrowser.browserServerWSEndpoint(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,6 @@ export class Extension implements RunHooks {
   }
 
   async onWillRunTests(config: TestConfig, debug: boolean) {
-    this._models.onWillRunTests();
     await this._reusedBrowser.onWillRunTests(config, debug);
     return {
       connectWsEndpoint: this._reusedBrowser.browserServerWSEndpoint(),

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -519,6 +519,8 @@ export class TestModel extends DisposableBase {
     if (token?.isCancellationRequested)
       return;
 
+    this._collection.onWillRunTests();
+
     // Run global setup with the first test.
     let globalSetupResult: reporterTypes.FullResult['status'] = 'passed';
     if (this.canRunGlobalHooks('setup'))
@@ -566,6 +568,8 @@ export class TestModel extends DisposableBase {
   async debugTests(request: vscodeTypes.TestRunRequest, reporter: reporterTypes.ReporterV2, token: vscodeTypes.CancellationToken) {
     if (token?.isCancellationRequested)
       return;
+
+    this._collection.onWillRunTests();
 
     // Underlying debugTest implementation will run the global setup.
     await this.runGlobalHooks('teardown', reporter, token);

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -519,7 +519,7 @@ export class TestModel extends DisposableBase {
     if (token?.isCancellationRequested)
       return;
 
-    this._collection.onWillRunTests();
+    this._collection._saveSettings();
 
     // Run global setup with the first test.
     let globalSetupResult: reporterTypes.FullResult['status'] = 'passed';
@@ -569,7 +569,7 @@ export class TestModel extends DisposableBase {
     if (token?.isCancellationRequested)
       return;
 
-    this._collection.onWillRunTests();
+    this._collection._saveSettings();
 
     // Underlying debugTest implementation will run the global setup.
     await this.runGlobalHooks('teardown', reporter, token);
@@ -828,7 +828,7 @@ export class TestModelCollection extends DisposableBase {
     this._didUpdate.fire();
   }
 
-  private _saveSettings() {
+  _saveSettings() {
     const workspaceSettings: WorkspaceSettings = { configs: [] };
     for (const model of this._models) {
       workspaceSettings.configs!.push({
@@ -839,10 +839,6 @@ export class TestModelCollection extends DisposableBase {
       });
     }
     this.embedder.context.workspaceState.update(workspaceStateKey, workspaceSettings);
-  }
-
-  onWillRunTests() {
-    this._saveSettings();
   }
 }
 

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -836,6 +836,10 @@ export class TestModelCollection extends DisposableBase {
     }
     this.embedder.context.workspaceState.update(workspaceStateKey, workspaceSettings);
   }
+
+  onWillRunTests() {
+    this._saveSettings();
+  }
 }
 
 export function projectFiles(project: TestProject): Map<string, reporterTypes.Suite> {

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -131,3 +131,99 @@ test('should reload when playwright.env changes', async ({ activate }) => {
   expect(output).toContain(`foo=foo-value`);
   expect(output).toContain(`bar={"prop":"bar-value"}`);
 });
+
+test('should sync project enabled state to workspace settings', async ({ activate }) => {
+  const { vscode, testController } = await activate({
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'foo', testMatch: 'foo.ts' },
+          { name: 'bar', testMatch: 'bar.ts' },
+        ]
+      });
+    `,
+  });
+
+  const webView = vscode.webViews.get('pw.extension.settingsView')!;
+
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - text: PROJECTS
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked=false]
+  `);
+  await testController.run(testController.findTestItems(/example.spec.ts/));
+  expect(vscode.context.workspaceState.get('pw.workspace-settings')).toEqual({
+    configs: [
+      {
+        enabled: true,
+        projects: [
+          {
+            enabled: true,
+            name: 'foo',
+          },
+          {
+            enabled: false,
+            name: 'bar',
+          },
+        ],
+        relativeConfigFile: 'playwright.config.ts',
+        selected: true,
+      },
+    ],
+  });
+
+  await webView.getByRole('checkbox', { name: 'bar' }).check();
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked]
+  `);
+  expect(vscode.context.workspaceState.get('pw.workspace-settings')).toEqual(expect.objectContaining({
+    configs: [
+      expect.objectContaining({
+        enabled: true,
+        projects: [
+          expect.objectContaining({ name: 'foo', enabled: true }),
+          expect.objectContaining({ name: 'bar', enabled: true }),
+        ]
+      })
+    ]
+  }));
+});
+
+test('should read project enabled state from workspace settings', async ({ vscode, activate }) => {
+  vscode.context.workspaceState.update('pw.workspace-settings', {
+    configs: [
+      {
+        relativeConfigFile: 'playwright.config.ts',
+        selected: true,
+        enabled: true,
+        projects: [
+          { name: 'foo', enabled: true },
+          { name: 'bar', enabled: false }
+        ]
+      }
+    ]
+  });
+
+  await activate({
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'foo', testMatch: 'foo.ts' },
+          { name: 'bar', testMatch: 'bar.ts' },
+          { name: 'baz', testMatch: 'baz.ts' },
+        ]
+      });
+    `,
+  });
+
+  const webView = vscode.webViews.get('pw.extension.settingsView')!;
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - text: PROJECTS
+    - checkbox "foo" [checked]
+    - checkbox "bar" [checked=false]
+    - checkbox "baz" [checked=false]
+  `);
+});


### PR DESCRIPTION
We store settings like activated projects in `pw.workspace-settings`. But we only write to it if it's modified, which means that users who never change anything about them don't get their settings stored. If we ever change the default settings, this means their workflows + muscle memory will be broken. Not good!

To prevent that from happening, this PR makes us `saveSettings()` before every test run. It also adds some tests to cover that.