### PR TITLE
fix(windows): clear diagnostics errors

### DIFF
--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -201,7 +201,7 @@ export class TestModel extends DisposableBase {
     }
 
     if (report.error?.location) {
-      this._errorByFile.set(report.error?.location.file, report.error);
+      this._errorByFile.set(this._vscode.Uri.file(report.error.location.file).fsPath, report.error);
       this._collection._modelUpdated(this);
       return;
     }
@@ -396,7 +396,7 @@ export class TestModel extends DisposableBase {
       this._errorByFile.deleteAll(requestedFile);
     for (const error of errors) {
       if (error.location)
-        this._errorByFile.set(error.location.file, error);
+        this._errorByFile.set(this._vscode.Uri.file(error.location.file).fsPath, error);
     }
 
     for (const [projectName, project] of this._projects) {
@@ -405,7 +405,7 @@ export class TestModel extends DisposableBase {
       const filesToClear = new Set(requestedFiles);
       for (const fileSuite of newProjectSuite?.suites || []) {
         // Do not show partial results in suites with errors.
-        if (this._errorByFile.has(fileSuite.location!.file))
+        if (this._errorByFile.has(this._vscode.Uri.file(fileSuite.location!.file).fsPath))
           continue;
         filesToClear.delete(fileSuite.location!.file);
         files.set(fileSuite.location!.file, fileSuite);


### PR DESCRIPTION
**Whats happening?**

The issue is that we write errors to a Map with "Node.js like paths" so that the drive-letter is **uppercase** but we delete them out of the map by using the VSCode workspace change event, which are VSCode like paths, which have **always lowercase drive letters**.

This PR wraps when calling `set` inside `this._vscode.Uri.file(path).fsPath` which normalises and is what we already do for other places when we interact with locations from the reporter API.

https://github.com/microsoft/playwright-vscode/blob/ffcd83afd0a4efd16c38c9ae86c44332f2484956/src/testModel.ts#L395-L396

Resolves https://github.com/microsoft/playwright/issues/34146
Resolves https://github.com/microsoft/playwright/issues/33671