### PR TITLE
fix: a few more conversions to the proper casing of windows paths

### DIFF
--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -201,7 +201,7 @@ export class TestModel extends DisposableBase {
     }
 
     if (report.error?.location) {
-      this._errorByFile.set(report.error?.location.file, report.error);
+      this._errorByFile.set(this._vscode.Uri.file(report.error.location.file).fsPath, report.error);
       this._collection._modelUpdated(this);
       return;
     }
@@ -396,7 +396,7 @@ export class TestModel extends DisposableBase {
       this._errorByFile.deleteAll(requestedFile);
     for (const error of errors) {
       if (error.location)
-        this._errorByFile.set(error.location.file, error);
+        this._errorByFile.set(this._vscode.Uri.file(error.location.file).fsPath, error);
     }
 
     for (const [projectName, project] of this._projects) {
@@ -405,7 +405,7 @@ export class TestModel extends DisposableBase {
       const filesToClear = new Set(requestedFiles);
       for (const fileSuite of newProjectSuite?.suites || []) {
         // Do not show partial results in suites with errors.
-        if (this._errorByFile.has(fileSuite.location!.file))
+        if (this._errorByFile.has(this._vscode.Uri.file(fileSuite.location!.file).fsPath))
           continue;
         filesToClear.delete(fileSuite.location!.file);
         files.set(fileSuite.location!.file, fileSuite);
@@ -641,7 +641,12 @@ export class TestModel extends DisposableBase {
         filesToWatch.add(include.uri.fsPath);
       }
     }
-    await this._playwrightTest.watchFiles([...filesToWatch]);
+
+    // Playwright expects uppercase drive letter on Windows.
+    let files = [...filesToWatch];
+    if (process.platform === 'win32')
+      files = files.map(file => file[0].toUpperCase() + file.substring(1));
+    await this._playwrightTest.watchFiles(files);
   }
 
   narrowDownLocations(request: vscodeTypes.TestRunRequest): { locations: string[] | null, testIds?: string[] } {

--- a/src/workspaceObserver.ts
+++ b/src/workspaceObserver.ts
@@ -40,7 +40,7 @@ export class WorkspaceObserver {
       if (this._folderWatchers.has(folder))
         continue;
 
-      const watcher = this._vscode.workspace.createFileSystemWatcher(folder.replaceAll(path.sep, '/') + '/**');
+      const watcher = this._vscode.workspace.createFileSystemWatcher(this._vscode.Uri.file(folder).fsPath.replaceAll(path.sep, '/') + '/**');
       const disposables: vscodeTypes.Disposable[] = [
         watcher.onDidCreate(uri => {
           if (uri.scheme === 'file')

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -34,6 +34,9 @@ export class Uri {
 
   static file(fsPath: string): Uri {
     const uri = new Uri();
+    // VSCode lowercases drive letters on Windows.
+    if (process.platform === 'win32' && fsPath && fsPath[0] !== '\\' && fsPath[0] !== '/')
+      fsPath = fsPath[0].toLowerCase() + fsPath.substring(1);
     uri.fsPath = fsPath;
     uri.path = fsPath;
     return uri;


### PR DESCRIPTION
VSCode expects lowercase drive letter, while Playwright expects uppercase drive letter. This includes fixes from #584 and more.

To properly test this, updated vscode mock to match vscode proper, which revealed a few failing tests:
```
    [default] › global-errors.spec.ts:19:5 › should report duplicate test title ────────────────────
    [default] › list-tests.spec.ts:442:5 › should forget tests after error before first test ───────
    [default] › problems.spec.ts:55:5 › should update diagnostics on file change ───────────────────
    [default] › watch.spec.ts:24:5 › should watch all tests ────────────────────────────────────────
    [default] › watch.spec.ts:147:5 › should watch test file ───────────────────────────────────────
    [default] › watch.spec.ts:198:5 › should watch tests via helper ────────────────────────────────
```

Watch fails because it tries to watch lowercase paths in Playwright. Errors through diagnostics fail because they update with both lowercase and uppercase paths.

Fixes https://github.com/microsoft/playwright/issues/34146.
Fixes https://github.com/microsoft/playwright/issues/33671.
