### PR TITLE
fix: ensure all paths use uppercase drive letter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,12 @@ module.exports = {
    */
   'rules': {
     '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
+
+    'no-restricted-properties': [2, {
+      'property': 'fsPath',
+      'message': 'Please use uriToPath(uri) instead.',
+    }],
+
     /**
        * Enforced rules
        */

--- a/src/debugHighlight.ts
+++ b/src/debugHighlight.ts
@@ -20,6 +20,7 @@ import { replaceActionWithLocator, locatorMethodRegex } from './methodNames';
 import type { Location } from './upstream/reporter';
 import { ReusedBrowser } from './reusedBrowser';
 import * as vscodeTypes from './vscodeTypes';
+import { normalizePath, uriToPath } from './utils';
 
 export type DebuggerError = { error: string, location: Location };
 
@@ -144,7 +145,7 @@ export type StackFrame = {
 const sessionsWithHighlight = new Set<vscodeTypes.DebugSession>();
 
 async function locatorToHighlight(debugSessions: Map<string, vscodeTypes.DebugSession>, document: vscodeTypes.TextDocument, position: vscodeTypes.Position, token?: vscodeTypes.CancellationToken): Promise<string | undefined> {
-  const fsPath = document.uri.fsPath;
+  const fsPath = uriToPath(document.uri);
 
   if (!debugSessions.size) {
     // When not debugging, discover all the locator-alike expressions.
@@ -183,7 +184,7 @@ async function locatorToHighlight(debugSessions: Map<string, vscodeTypes.DebugSe
       if (!stackFrame.source)
         continue;
       const sourcePath = mapRemoteToLocalPath(stackFrame.source.path);
-      if (!sourcePath || document.uri.fsPath !== sourcePath)
+      if (!sourcePath || fsPath !== normalizePath(sourcePath))
         continue;
       if (token?.isCancellationRequested)
         return;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -19,6 +19,7 @@ import fs from 'fs';
 import os from 'os';
 import * as vscodeTypes from './vscodeTypes';
 import { TestModel } from './testModel';
+import { uriToPath } from './utils';
 
 export async function installPlaywright(vscode: vscodeTypes.VSCode) {
   const [workspaceFolder] = vscode.workspace.workspaceFolders || [];
@@ -45,7 +46,7 @@ export async function installPlaywright(vscode: vscodeTypes.VSCode) {
 
   const terminal = vscode.window.createTerminal({
     name: 'Install Playwright',
-    cwd: workspaceFolder.uri.fsPath,
+    cwd: uriToPath(workspaceFolder.uri),
     env: process.env,
   });
 

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -75,7 +75,7 @@ export class PlaywrightTestServer {
     }, {
       mergeProjects: true,
       mergeTestCases: true,
-      resolvePath: (rootDir: string, relativePath: string) => this._vscode.Uri.file(path.join(rootDir, relativePath)).fsPath,
+      resolvePath,
     });
     for (const message of report)
       teleReceiver.dispatch(message);
@@ -94,7 +94,7 @@ export class PlaywrightTestServer {
     const teleReceiver = new TeleReporterReceiver(reporter, {
       mergeProjects: true,
       mergeTestCases: true,
-      resolvePath: (rootDir: string, relativePath: string) => this._vscode.Uri.file(path.join(rootDir, relativePath)).fsPath,
+      resolvePath,
     });
     for (const message of report)
       teleReceiver.dispatch(message);
@@ -111,7 +111,7 @@ export class PlaywrightTestServer {
     const teleReceiver = new TeleReporterReceiver(testListener, {
       mergeProjects: true,
       mergeTestCases: true,
-      resolvePath: (rootDir: string, relativePath: string) => this._vscode.Uri.file(path.join(rootDir, relativePath)).fsPath,
+      resolvePath,
     });
     const disposable = testServer.onStdio(params => {
       if (params.type === 'stdout')
@@ -390,7 +390,7 @@ export class PlaywrightTestServer {
     const teleReceiver = new TeleReporterReceiver(reporter, {
       mergeProjects: true,
       mergeTestCases: true,
-      resolvePath: (rootDir: string, relativePath: string) => this._vscode.Uri.file(path.join(rootDir, relativePath)).fsPath,
+      resolvePath,
     });
     return new Promise<void>(resolve => {
       const disposables = [
@@ -412,7 +412,7 @@ export class PlaywrightTestServer {
   }
 
   private _testFilesChanged(testFiles: string[]) {
-    this._model.testFilesChanged(testFiles.map(f => this._vscode.Uri.file(f).fsPath));
+    this._model.testFilesChanged(testFiles);
   }
 
   private _disposeTestServer() {
@@ -425,4 +425,8 @@ export class PlaywrightTestServer {
 
 function unwrapString(params: { text?: string, buffer?: string }): string | Buffer {
   return params.buffer ? Buffer.from(params.buffer, 'base64') : params.text || '';
+}
+
+function resolvePath(rootDir: string, relativePath: string) {
+  return path.join(rootDir, relativePath);
 }

--- a/src/reporterServer.ts
+++ b/src/reporterServer.ts
@@ -95,7 +95,7 @@ export class ReporterServer {
     const teleReceiver = new TeleReporterReceiver(listener, {
       mergeProjects: true,
       mergeTestCases: true,
-      resolvePath: (rootDir: string, relativePath: string) => this._vscode.Uri.file(path.join(rootDir, relativePath)).fsPath,
+      resolvePath: (rootDir: string, relativePath: string) => path.join(rootDir, relativePath),
     });
 
     transport.onmessage = message => {

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -201,7 +201,7 @@ export class TestModel extends DisposableBase {
     }
 
     if (report.error?.location) {
-      this._errorByFile.set(report.error?.location.file, report.error);
+      this._errorByFile.set(this._vscode.Uri.file(report.error.location.file).fsPath, report.error);
       this._collection._modelUpdated(this);
       return;
     }
@@ -396,7 +396,7 @@ export class TestModel extends DisposableBase {
       this._errorByFile.deleteAll(requestedFile);
     for (const error of errors) {
       if (error.location)
-        this._errorByFile.set(error.location.file, error);
+        this._errorByFile.set(this._vscode.Uri.file(error.location.file).fsPath, error);
     }
 
     for (const [projectName, project] of this._projects) {
@@ -405,7 +405,7 @@ export class TestModel extends DisposableBase {
       const filesToClear = new Set(requestedFiles);
       for (const fileSuite of newProjectSuite?.suites || []) {
         // Do not show partial results in suites with errors.
-        if (this._errorByFile.has(fileSuite.location!.file))
+        if (this._errorByFile.has(this._vscode.Uri.file(fileSuite.location!.file).fsPath))
           continue;
         filesToClear.delete(fileSuite.location!.file);
         files.set(fileSuite.location!.file, fileSuite);
@@ -641,7 +641,12 @@ export class TestModel extends DisposableBase {
         filesToWatch.add(include.uri.fsPath);
       }
     }
-    await this._playwrightTest.watchFiles([...filesToWatch]);
+
+    // Playwright expects uppercase drive letter on Windows.
+    let files = [...filesToWatch];
+    if (process.platform === 'win32')
+      files = files.map(file => file[0].toUpperCase() + file.substring(1));
+    await this._playwrightTest.watchFiles(files);
   }
 
   narrowDownLocations(request: vscodeTypes.TestRunRequest): { locations: string[] | null, testIds?: string[] } {

--- a/src/workspaceObserver.ts
+++ b/src/workspaceObserver.ts
@@ -16,6 +16,7 @@
 
 import path from 'path';
 import * as vscodeTypes from './vscodeTypes';
+import { uriToPath } from './utils';
 
 export type WorkspaceChange = {
   created: Set<string>;
@@ -40,19 +41,21 @@ export class WorkspaceObserver {
       if (this._folderWatchers.has(folder))
         continue;
 
+      // Make sure to use lowercase drive letter in the pattern.
+      // eslint-disable-next-line no-restricted-properties
       const watcher = this._vscode.workspace.createFileSystemWatcher(this._vscode.Uri.file(folder).fsPath.replaceAll(path.sep, '/') + '/**');
       const disposables: vscodeTypes.Disposable[] = [
         watcher.onDidCreate(uri => {
           if (uri.scheme === 'file')
-            this._change().created.add(uri.fsPath);
+            this._change().created.add(uriToPath(uri));
         }),
         watcher.onDidChange(uri => {
           if (uri.scheme === 'file')
-            this._change().changed.add(uri.fsPath);
+            this._change().changed.add(uriToPath(uri));
         }),
         watcher.onDidDelete(uri => {
           if (uri.scheme === 'file')
-            this._change().deleted.add(uri.fsPath);
+            this._change().deleted.add(uriToPath(uri));
         }),
         watcher,
       ];

--- a/src/workspaceObserver.ts
+++ b/src/workspaceObserver.ts
@@ -40,7 +40,7 @@ export class WorkspaceObserver {
       if (this._folderWatchers.has(folder))
         continue;
 
-      const watcher = this._vscode.workspace.createFileSystemWatcher(folder.replaceAll(path.sep, '/') + '/**');
+      const watcher = this._vscode.workspace.createFileSystemWatcher(this._vscode.Uri.file(folder).fsPath.replaceAll(path.sep, '/') + '/**');
       const disposables: vscodeTypes.Disposable[] = [
         watcher.onDidCreate(uri => {
           if (uri.scheme === 'file')

--- a/tests/debug-tests.spec.ts
+++ b/tests/debug-tests.spec.ts
@@ -127,7 +127,7 @@ test('should debug error', async ({ activate }, testInfo) => {
   profile.run(testItems);
   const testRun = await testRunPromise;
 
-  await expect.poll(() => vscode.debug.output).toContain('READY TO BREAK');
+  await expect.poll(() => vscode.debug.output, { timeout: 10000 }).toContain('READY TO BREAK');
 
   vscode.debug.simulateStoppedOnError('Error on line 10', { file: testInfo.outputPath('tests/test.spec.ts'), line: 10 });
 
@@ -164,7 +164,7 @@ test('should end test run when stopping the debugging', async ({ activate }, tes
   const testRunPromise = new Promise<TestRun>(f => testController.onDidCreateTestRun(f));
   profile.run(testItems);
   const testRun = await testRunPromise;
-  await expect.poll(() => vscode.debug.output).toContain('READY TO BREAK');
+  await expect.poll(() => vscode.debug.output, { timeout: 10000 }).toContain('READY TO BREAK');
 
   const endPromise = new Promise(f => testRun.onDidEnd(f));
   vscode.debug.stopDebugging();

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -34,6 +34,9 @@ export class Uri {
 
   static file(fsPath: string): Uri {
     const uri = new Uri();
+    // VSCode lowercases drive letters on Windows.
+    if (process.platform === 'win32' && fsPath && fsPath[0] !== '\\' && fsPath[0] !== '/')
+      fsPath = fsPath[0].toLowerCase() + fsPath.substring(1);
     uri.fsPath = fsPath;
     uri.path = fsPath;
     return uri;

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -24,6 +24,8 @@ import which from 'which';
 import { Browser, Page } from '@playwright/test';
 import { CancellationToken } from '../../src/vscodeTypes';
 
+/* eslint-disable no-restricted-properties */
+
 export class Uri {
   scheme = 'file';
   authority = '';


### PR DESCRIPTION
VSCode expects lowercase drive letter, while Playwright expects uppercase drive letter. This introduces bugs where we accidentally use two different casings for paths.

To achieve this and avoid future issues with path casing mismatch:
- make mock vscode lowercase the drive letter to match real vscode - this exposed a few tests that fail due to drive letter mismatch:
  ```
    [default] › global-errors.spec.ts:19:5 › should report duplicate test title ────────────────────
    [default] › list-tests.spec.ts:442:5 › should forget tests after error before first test ───────
    [default] › problems.spec.ts:55:5 › should update diagnostics on file change ───────────────────
    [default] › watch.spec.ts:24:5 › should watch all tests ────────────────────────────────────────
    [default] › watch.spec.ts:147:5 › should watch test file ───────────────────────────────────────
    [default] › watch.spec.ts:198:5 › should watch tests via helper ────────────────────────────────
  ```
- internally, use Playwright-style uppercase drive letter paths everywhere;
- when interacting with VSCode through uri, either use `uriToPath(uri)` or `vscode.Uri.file(path)`;
- ban `Uri.fsPath` so that we never use VSCode-style lowercase paths.

This change superseedes #584.

Fixes https://github.com/microsoft/playwright/issues/34146.
Fixes https://github.com/microsoft/playwright/issues/33671.
