### PR TITLE
fix: limit decorations to prevent editor slowdown

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -687,6 +687,9 @@ export class Extension implements RunHooks {
             }
           });
         }
+
+        if (completedDecorations.length > 1000) // too many decorations slow down the editor
+          break;
       }
 
       editor.setDecorations(this._activeStepDecorationType, activeDecorations);


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/34248

Updating decorations slows down the editor when the number of decorations is too high. We can work around it by limiting the number of decorations.