### PR TITLE
fix: make create-playwright work under CMD

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -67,7 +67,7 @@ export async function installPlaywright(vscode: vscodeTypes.VSCode) {
   if (result.includes(installDepsItem))
     args.push('--install-deps');
 
-  terminal.sendText(`npm init playwright@latest --yes ${quote('--')} ${quote('--quiet')} ${args.map(quote).join(' ')}`, true);
+  terminal.sendText(`npm init playwright@latest --yes "--" . ${quote('--quiet')} ${args.map(quote).join(' ')}`, true);
 }
 
 function quote(s: string): string {


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/34266. When we create the terminal, we don't know whether it's bash, Powershell, CMD or anything else. The VS Code API also doesn't give a good API to control that. So we need our `npm init` command to work under all three shells.

https://github.com/microsoft/playwright-vscode/pull/526 fixed a bug with NPM and Powershell, but regressed CMD:

<img width="1097" alt="Screenshot 2025-01-10 at 13 58 12" src="https://github.com/user-attachments/assets/0b49af09-0d50-40a2-8e16-0867fc5a5325" />

Look at the bottom line: Under CMD, it incorrectly picks up `'--'` as the directory to create the project in.

I've played around with it, and found a command that's interpreted the same by all three shells:

![](https://github.com/user-attachments/assets/77aea7a4-a1c8-4df2-8fe9-e3fabca111c9)
*cmd*

![](https://github.com/user-attachments/assets/aafbcb03-2d8c-4bf6-a1b2-c029da4b07dd)
*powershell*

![](https://github.com/user-attachments/assets/49b8aeb9-d28e-4968-aecf-e648b7dcb990)
*zsh*