### PR TITLE
fix: show at most one decoration per line

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -675,25 +675,23 @@ export class Extension implements RunHooks {
           activeDecorations.push({ range: location.range });
       }
 
-      const completedDecorations: vscodeTypes.DecorationOptions[] = [];
+      const completedDecorations: Record<number, vscodeTypes.DecorationOptions> = {};
       for (const { location, duration } of completed) {
         if (uriToPath(location.uri) === uriToPath(editor.document.uri)) {
-          completedDecorations.push({
+          const line = location.range.start.line;
+          completedDecorations[line] = {
             range: location.range,
             renderOptions: {
               after: {
                 contentText: ` \u2014 ${duration}ms`
               }
             }
-          });
+          };
         }
-
-        if (completedDecorations.length > 1000) // too many decorations slow down the editor
-          break;
       }
 
       editor.setDecorations(this._activeStepDecorationType, activeDecorations);
-      editor.setDecorations(this._completedStepDecorationType, completedDecorations);
+      editor.setDecorations(this._completedStepDecorationType, Object.values(completedDecorations));
     }
 
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -669,15 +669,16 @@ export class Extension implements RunHooks {
     const completed = [...this._completedSteps.values()];
 
     for (const editor of this._vscode.window.visibleTextEditors) {
+      const editorPath = uriToPath(editor.document.uri);
       const activeDecorations: vscodeTypes.DecorationOptions[] = [];
       for (const { location } of active) {
-        if (uriToPath(location.uri) === uriToPath(editor.document.uri))
+        if (uriToPath(location.uri) === editorPath)
           activeDecorations.push({ range: location.range });
       }
 
       const completedDecorations: Record<number, vscodeTypes.DecorationOptions> = {};
       for (const { location, duration } of completed) {
-        if (uriToPath(location.uri) === uriToPath(editor.document.uri)) {
+        if (uriToPath(location.uri) === editorPath) {
           const line = location.range.start.line;
           completedDecorations[line] = {
             range: location.range,


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright-vscode/pull/590.

Instead of capping the number of decorations per file, we now show at most one decoration per line. This still places a good upper limit so we don't overwhelm VS Code rendering with too many decorations. But it also prevents the confusing UI of decorations abruptly cutting off.

https://github.com/user-attachments/assets/3073f5bb-995b-436a-ac4d-de2c59c517c8

