### PR TITLE
feat: provide page snapshot as context to copilot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.23.2",
-        "@playwright/test": "1.50.0-beta-1738269400000",
+        "@playwright/test": "1.51.0-alpha-2025-02-11",
         "@types/babel__core": "^7.20.3",
         "@types/babel__helper-plugin-utils": "^7.10.2",
         "@types/babel__traverse": "^7.20.3",
@@ -1435,12 +1435,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.0-beta-1738269400000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0-beta-1738269400000.tgz",
-      "integrity": "sha512-U1PTgIQyAYvdjEDCv5laVsNbT6T1pPD2YFZ/QyO7qBVxUPyN+X9xtFPjUAGCpnlOEjvjXnHS781imwf+zyNkng==",
+      "version": "1.51.0-alpha-2025-02-11",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0-alpha-2025-02-11.tgz",
+      "integrity": "sha512-2NPhWR6IbHkP46FzYcxxuCi0Nx6qh0mVsp+6134YD7AQOvbJHpxC/F0LPgkBz0siT2/bUCsBuRGK63v6Kbz4xA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.0-beta-1738269400000"
+        "playwright": "1.51.0-alpha-2025-02-11"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3571,6 +3572,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4875,12 +4877,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.0-beta-1738269400000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0-beta-1738269400000.tgz",
-      "integrity": "sha512-xzSBzQ1rFnyJ2AXdsZuDADgn7moseRxOsFQzT/0vWOBGMypNPY0DhKJa10gqgQeLbdnmbIBcrMCPoOJtwJXTuA==",
+      "version": "1.51.0-alpha-2025-02-11",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0-alpha-2025-02-11.tgz",
+      "integrity": "sha512-H2gtHXJGYb90I886dzW15jJlfZhwNuzmIqxmgFtiQyDKYOoiY+i1/rUjg+1m9sC0YHHaLlupt0n/cIyN6Rm6tw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.0-beta-1738269400000"
+        "playwright-core": "1.51.0-alpha-2025-02-11"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4893,10 +4896,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.0-beta-1738269400000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0-beta-1738269400000.tgz",
-      "integrity": "sha512-uDcjv6KyQgbLiNLpdajnjP+bQNgWBWJfjIJDrvjfkQGue6bvOjAHi3YaW1AyiECBBmvQ+lnv2dOcSasNW5quMA==",
+      "version": "1.51.0-alpha-2025-02-11",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0-alpha-2025-02-11.tgz",
+      "integrity": "sha512-B5hKfUOhQ4bjK48aK4HuxYPQsWjuDLb6CeHCUzIMvuSwycvJ+LMZf7XxZPtFd8Aw+oliuo6nveZ8EceqXNB67w==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.2",
-    "@playwright/test": "1.50.0-beta-1738269400000",
+    "@playwright/test": "1.51.0-alpha-2025-02-11",
     "@types/babel__core": "^7.20.3",
     "@types/babel__helper-plugin-utils": "^7.10.2",
     "@types/babel__traverse": "^7.20.3",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -603,7 +603,7 @@ export class Extension implements RunHooks {
     const snapshot = result.attachments.find(a => a.name === 'pageSnapshot');
     if (snapshot && snapshot.path) {
       const contents = await this._vscode.workspace.fs.readFile(this._vscode.Uri.file(snapshot.path));
-      aiContext = `### Page Snapshot at Failure\n${contents.toString()}`; // cannot use ``` codeblocks, vscode markdown does not support it
+      aiContext = `### Page Snapshot at Failure\n\n${contents.toString()}`; // cannot use ``` codeblocks, vscode markdown does not support it
     }
 
     testRun.failed(testItem, result.errors.map(error => this._testMessageForTestError(error, aiContext)), result.duration);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -520,7 +520,7 @@ export class Extension implements RunHooks {
         }
       },
 
-      onTestEnd: (test: reporterTypes.TestCase, result: reporterTypes.TestResult) => {
+      onTestEnd: async (test: reporterTypes.TestCase, result: reporterTypes.TestResult) => {
         if (result.errors.find(e => e.message?.includes(`Error: browserType.launch: Executable doesn't exist`)))
           browserDoesNotExist = true;
 
@@ -554,7 +554,7 @@ export class Extension implements RunHooks {
         const snapshot = result.attachments.find(a => a.name === 'pageSnapshot');
         if (snapshot && snapshot.path) {
           const contents = await this._vscode.workspace.fs.readFile(this._vscode.Uri.file(snapshot.path));
-          aiContext = `### Page Snapshot at Failure\n${contents}`;
+          aiContext = `### Page Snapshot at Failure\n${contents.toString()}`; // cannot use ``` codeblocks, vscode markdown does not support it
         }
 
         testRun.failed(testItem, result.errors.map(error => this._testMessageForTestError(error, aiContext)), result.duration);

--- a/src/playwrightTestTypes.ts
+++ b/src/playwrightTestTypes.ts
@@ -34,6 +34,7 @@ export type PlaywrightTestRunOptions = {
   connectWsEndpoint?: string;
   updateSnapshots?: 'all' | 'changed' | 'missing' | 'none' | undefined;
   updateSourceMethod?: 'overwrite' | 'patch' | '3way' | undefined;
+  pageSnapshot?: 'on' | 'off' | 'only-on-failure';
 };
 
 export interface RunHooks {

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -551,6 +551,7 @@ export class TestModel extends DisposableBase {
       connectWsEndpoint: showBrowser ? externalOptions.connectWsEndpoint : undefined,
       updateSnapshots: noOverrideToUndefined(this._embedder.settingsModel.updateSnapshots.get()),
       updateSourceMethod: noOverrideToUndefined(this._embedder.settingsModel.updateSourceMethod.get()),
+      pageSnapshot: 'only-on-failure',
     };
 
     try {

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -924,7 +924,13 @@ export class VSCode {
   languages: any = {};
   tests: any = {};
   window: any = {};
-  workspace: any = {};
+  workspace: any = {
+    fs: {
+      async readFile(path: Uri) {
+        return await fs.promises.readFile(path.fsPath);
+      }
+    }
+  };
   env: any = {
     uiKind: UIKind.Desktop,
     remoteName: undefined,

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1299,7 +1299,9 @@ test.describe('runGlobalSetupOnEachRun', { annotation: { type: 'issue', descript
   });
 });
 
-test('should provide page snapshot to copilot', async ({ activate }) => {
+test('should provide page snapshot to copilot', async ({ activate, overridePlaywrightVersion }) => {
+  test.skip(!!overridePlaywrightVersion, 'requires testserver');
+
   const { testController } = await activate({
     'playwright.config.js': `module.exports = { testDir: 'tests', workers: 2 }`,
     'tests/test1.spec.ts': `

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1306,14 +1306,8 @@ test('should provide page snapshot to copilot', async ({ activate }) => {
       import { test, expect } from '@playwright/test';
       import * as fs from 'node:fs/promises';
 
-      // remove once real pageSnapshot lands
-      test.afterEach(async () => {
-        const path = test.info().outputPath('pageSnapshot');
-        await fs.writeFile(path, '- button "click me"');
-        await test.info().attach('pageSnapshot', { path });
-      });
-
       test('one', async ({ page }) => {
+        await page.setContent('<button>click me</button>');
         expect(1).toBe(2);
       });
     `,

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1299,4 +1299,30 @@ test.describe('runGlobalSetupOnEachRun', { annotation: { type: 'issue', descript
   });
 });
 
+test('should provide page snapshot to copilot', async ({ activate }) => {
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests', workers: 2 }`,
+    'tests/test1.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      import * as fs from 'node:fs/promises';
+
+      // remove once real pageSnapshot lands
+      test.afterEach(async () => {
+        const path = test.info().outputPath('pageSnapshot');
+        await fs.writeFile(path, '- button "click me"');
+        await test.info().attach('pageSnapshot', { path });
+      });
+
+      test('one', async ({ page }) => {
+        expect(1).toBe(2);
+      });
+    `,
+  });
+
+  const testRun = await testController.run();
+  const log = testRun.renderLog({ messages: true });
+  expect(log).toContain(`## Context for AI`);
+  expect(log).toContain(`### Page Snapshot at Failure`);
+  expect(log).toContain(`- button "click me"`);
+});
 


### PR DESCRIPTION
Enables `pageSnapshot: 'only-on-failure'` for all test runs through the extension, and injects the page snapshot into the error message that Copilot uses to fix test failures.

<img width="1267" alt="Screenshot 2025-02-11 at 11 00 45" src="https://github.com/user-attachments/assets/59715004-5286-41b3-9b5b-666841ff0730" />

related to https://github.com/microsoft/playwright/issues/34476
