### PR TITLE
fix: running folder should use folder path as arg

### DIFF
--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -652,7 +652,7 @@ export class TestModel extends DisposableBase {
       if (treeItem.kind === 'group' && (treeItem.subKind === 'folder' || treeItem.subKind === 'file')) {
         for (const file of this.enabledFiles()) {
           if (file === treeItem.location.file || file.startsWith(treeItem.location.file))
-            locations.add(treeItem.location.file);
+            locations.add(treeItem.location.file + (treeItem.subKind === 'folder' ? path.sep : ''));
         }
       } else {
         testIds.push(...collectTestIds(treeItem));

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -204,7 +204,7 @@ test('should run folder', async ({ activate }) => {
     `,
   });
 
-  const testItems = testController.findTestItems(/folder/);
+  const testItems = testController.findTestItems(/folder$/);
   expect(testItems.length).toBe(1);
   const testRun = await testController.run(testItems);
 
@@ -221,7 +221,7 @@ test('should run folder', async ({ activate }) => {
 
   await expect(vscode).toHaveExecLog(`
     > playwright list-files -c playwright.config.js
-    > playwright test -c playwright.config.js tests/folder
+    > playwright test -c playwright.config.js tests/folder/
   `);
   await expect(vscode).toHaveConnectionLog([
     { method: 'listFiles', params: {} },
@@ -229,7 +229,7 @@ test('should run folder', async ({ activate }) => {
     {
       method: 'runTests',
       params: expect.objectContaining({
-        locations: [expect.stringContaining(`tests${escapedPathSep}folder`)],
+        locations: [expect.stringContaining(`tests${escapedPathSep}folder${escapedPathSep}`)],
         testIds: undefined
       })
     },


### PR DESCRIPTION
Part of https://github.com/microsoft/playwright/issues/34813. When running a folder item, we should send `folder/` to playwright, not `folder` (note the trailing slash). 