### PR TITLE
fix: running a folder shouldn't also run folders that share prefix

### DIFF
--- a/src/playwrightTestCLI.ts
+++ b/src/playwrightTestCLI.ts
@@ -18,7 +18,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import { ConfigFindRelatedTestFilesReport, ConfigListFilesReport } from './listTests';
 import { ReporterServer } from './reporterServer';
-import { escapeRegex, findNode, pathSeparator, preventRegexLookalike, runNode, uriToPath } from './utils';
+import { escapeRegex, findNode, pathSeparator, relativePreserveDirectory, runNode, uriToPath } from './utils';
 import * as vscodeTypes from './vscodeTypes';
 import * as reporterTypes from './upstream/reporter';
 import type { PlaywrightTestOptions, PlaywrightTestRunOptions } from './playwrightTestTypes';
@@ -109,7 +109,7 @@ export class PlaywrightTestCLI {
 
     {
       // For tests.
-      const relativeLocations = locations.map(f => path.relative(configFolder, f)).map(escapeRegex).sort();
+      const relativeLocations = locations.map(f => relativePreserveDirectory(configFolder, f)).map(escapeRegex).sort();
       const printArgs = extraArgs.filter(a => !a.includes('--repeat-each') && !a.includes('--retries') && !a.includes('--workers') && !a.includes('--trace'));
       this._log(`${escapeRegex(path.relative(this._model.config.workspaceFolder, configFolder))}> playwright test -c ${configFile}${printArgs.length ? ' ' + printArgs.join(' ') : ''}${relativeLocations.length ? ' ' + relativeLocations.join(' ') : ''}`);
     }
@@ -119,7 +119,7 @@ export class PlaywrightTestCLI {
       'test',
       '-c', configFile,
       ...extraArgs,
-      ...escapedLocations.map(preventRegexLookalike),
+      ...escapedLocations,
     ], {
       cwd: configFolder,
       stdio: ['pipe', 'pipe', 'pipe', 'pipe', 'pipe'],

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -22,7 +22,7 @@ import { TeleReporterReceiver } from './upstream/teleReceiver';
 import { TestServerConnection } from './upstream/testServerConnection';
 import { startBackend } from './backend';
 import type { PlaywrightTestOptions, PlaywrightTestRunOptions } from './playwrightTestTypes';
-import { escapeRegex, pathSeparator, preventRegexLookalike } from './utils';
+import { escapeRegex, pathSeparator } from './utils';
 import { debugSessionName } from './debugSessionName';
 import type { TestModel } from './testModel';
 import { TestServerInterface } from './upstream/testServerInterface';
@@ -91,7 +91,7 @@ export class PlaywrightTestServer {
     if (!connection)
       return;
     // Locations are regular expressions.
-    locations = locations.map(preventRegexLookalike).map(escapeRegex);
+    locations = locations.map(escapeRegex);
     const { report } = await connection.listTests({ locations });
     const teleReceiver = new TeleReporterReceiver(reporter, {
       mergeProjects: true,
@@ -178,7 +178,7 @@ export class PlaywrightTestServer {
       return;
 
     // Locations are regular expressions.
-    const locationPatterns = locations ? locations.map(preventRegexLookalike).map(escapeRegex) : undefined;
+    const locationPatterns = locations ? locations.map(escapeRegex) : undefined;
     const options: Parameters<TestServerInterface['runTests']>['0'] = {
       projects: this._model.enabledProjectsFilter(),
       locations: locationPatterns,
@@ -302,7 +302,7 @@ export class PlaywrightTestServer {
         return;
 
       // Locations are regular expressions.
-      const locationPatterns = locations ? locations.map(preventRegexLookalike).map(escapeRegex) : undefined;
+      const locationPatterns = locations ? locations.map(escapeRegex) : undefined;
       const options: Parameters<TestServerInterface['runTests']>['0'] = {
         projects: this._model.enabledProjectsFilter(),
         locations: locationPatterns,

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -22,7 +22,7 @@ import { TeleReporterReceiver } from './upstream/teleReceiver';
 import { TestServerConnection } from './upstream/testServerConnection';
 import { startBackend } from './backend';
 import type { PlaywrightTestOptions, PlaywrightTestRunOptions } from './playwrightTestTypes';
-import { escapeRegex, pathSeparator } from './utils';
+import { escapeRegex, pathSeparator, preventRegexLookalike } from './utils';
 import { debugSessionName } from './debugSessionName';
 import type { TestModel } from './testModel';
 import { TestServerInterface } from './upstream/testServerInterface';
@@ -91,7 +91,7 @@ export class PlaywrightTestServer {
     if (!connection)
       return;
     // Locations are regular expressions.
-    locations = locations.map(escapeRegex);
+    locations = locations.map(preventRegexLookalike).map(escapeRegex);
     const { report } = await connection.listTests({ locations });
     const teleReceiver = new TeleReporterReceiver(reporter, {
       mergeProjects: true,
@@ -178,7 +178,7 @@ export class PlaywrightTestServer {
       return;
 
     // Locations are regular expressions.
-    const locationPatterns = locations ? locations.map(escapeRegex) : undefined;
+    const locationPatterns = locations ? locations.map(preventRegexLookalike).map(escapeRegex) : undefined;
     const options: Parameters<TestServerInterface['runTests']>['0'] = {
       projects: this._model.enabledProjectsFilter(),
       locations: locationPatterns,
@@ -302,7 +302,7 @@ export class PlaywrightTestServer {
         return;
 
       // Locations are regular expressions.
-      const locationPatterns = locations ? locations.map(escapeRegex) : undefined;
+      const locationPatterns = locations ? locations.map(preventRegexLookalike).map(escapeRegex) : undefined;
       const options: Parameters<TestServerInterface['runTests']>['0'] = {
         projects: this._model.enabledProjectsFilter(),
         locations: locationPatterns,

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -650,9 +650,10 @@ export class TestModel extends DisposableBase {
     for (const item of request.include) {
       const treeItem = upstreamTreeItem(item);
       if (treeItem.kind === 'group' && (treeItem.subKind === 'folder' || treeItem.subKind === 'file')) {
+        const treeItemPath = treeItem.location.file + (treeItem.subKind === 'folder' ? path.sep : '');
         for (const file of this.enabledFiles()) {
-          if (file === treeItem.location.file || file.startsWith(treeItem.location.file))
-            locations.add(treeItem.location.file);
+          if (file === treeItemPath || file.startsWith(treeItemPath))
+            locations.add(treeItemPath);
         }
       } else {
         testIds.push(...collectTestIds(treeItem));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,3 +210,11 @@ export function normalizePath(fsPath: string): string {
     return fsPath[0].toUpperCase() + fsPath.substring(1);
   return fsPath;
 }
+
+// Playwright interprets absolute paths to folders as Regexes.
+export function preventRegexLookalike(location: string) {
+  const path = location.split(':')[0];
+  if (path.startsWith('/') && path.endsWith('/'))
+    return location.substring(1);
+  return location;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,7 +140,16 @@ async function findNodeViaShell(vscode: vscodeTypes.VSCode, cwd: string): Promis
   });
 }
 
+export function relativePreserveDirectory(from: string, to: string) {
+  const relative = path.relative(from, to);
+  return to.endsWith('/') ? relative + '/' : relative;
+}
+
 export function escapeRegex(text: string) {
+  // playwright interprets absolute paths as regex,
+  // removing the leading slash prevents that.
+  if (text.startsWith('/'))
+    text = text.substring(1);
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
@@ -209,12 +218,4 @@ export function normalizePath(fsPath: string): string {
   if (process.platform === 'win32' && fsPath?.length && fsPath[0] !== '/' && fsPath[0] !== '\\')
     return fsPath[0].toUpperCase() + fsPath.substring(1);
   return fsPath;
-}
-
-// Playwright interprets absolute paths to folders as Regexes.
-export function preventRegexLookalike(location: string) {
-  const path = location.split(':')[0];
-  if (path.startsWith('/') && path.endsWith('/'))
-    return location.substring(1);
-  return location;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,7 +142,7 @@ async function findNodeViaShell(vscode: vscodeTypes.VSCode, cwd: string): Promis
 
 export function relativePreserveDirectory(from: string, to: string) {
   const relative = path.relative(from, to);
-  return to.endsWith('/') ? relative + '/' : relative;
+  return to.endsWith(path.sep) ? relative + path.sep : relative;
 }
 
 export function escapeRegex(text: string) {

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -225,7 +225,7 @@ test('should run folder', async ({ activate }) => {
 
   await expect(vscode).toHaveExecLog(`
     > playwright list-files -c playwright.config.js
-    > playwright test -c playwright.config.js tests/folder
+    > playwright test -c playwright.config.js tests/folder/
   `);
   await expect(vscode).toHaveConnectionLog([
     { method: 'listFiles', params: {} },
@@ -233,7 +233,7 @@ test('should run folder', async ({ activate }) => {
     {
       method: 'runTests',
       params: expect.objectContaining({
-        locations: [expect.stringContaining(`tests${escapedPathSep}folder`)],
+        locations: [expect.stringContaining(`tests${escapedPathSep}folder${escapedPathSep}`)],
         testIds: undefined
       })
     },

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -202,9 +202,13 @@ test('should run folder', async ({ activate }) => {
       import { test } from '@playwright/test';
       test('two', async () => {});
     `,
+    'tests/folderwithsuffix/test2.spec.ts': `
+      import { test } from '@playwright/test';
+      test('two', async () => {});
+    `,
   });
 
-  const testItems = testController.findTestItems(/folder/);
+  const testItems = testController.findTestItems(/folder$/);
   expect(testItems.length).toBe(1);
   const testRun = await testController.run(testItems);
 

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -443,7 +443,7 @@ test('should only create test run if folder belongs to context', async ({ activa
   await expect(vscode).toHaveExecLog(`
     tests1> playwright list-files -c playwright.config.js
     tests2> playwright list-files -c playwright.config.js
-    tests1> playwright test -c playwright.config.js foo1
+    tests1> playwright test -c playwright.config.js foo1/
   `);
   await expect(vscode).toHaveConnectionLog([
     { method: 'listFiles', params: {} },


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/34813. When running the `foo` folder, we were sending `foo` over the wire instead of `foo/`. That meant that the `foobar/` folder also gets executed, which isn't expected.

The fix is to include the trailing slash in the locations we send to Playwright. Because Playwright interprets `/root/project/dir/` as a regular expression, I made it omit the leading slash for absolute directories. That has the same effect, because Playwright's location checker isn't strict.