### PR TITLE
chore: remove x-playwright-debug-controller header

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -76,13 +76,9 @@ export class BackendClient extends EventEmitter {
     return wsEndpoint;
   }
 
-  rewriteWsHeaders(headers: Record<string, string>): Record<string, string> {
-    return headers;
-  }
-
   async _connect(wsEndpoint: string) {
     this.wsEndpoint = wsEndpoint;
-    this._transport = await WebSocketTransport.connect(this.rewriteWsEndpoint(wsEndpoint), this.rewriteWsHeaders({}));
+    this._transport = await WebSocketTransport.connect(this.rewriteWsEndpoint(wsEndpoint));
     this._transport.onmessage = (message: any) => {
       if (!message.id) {
         this.emit(message.method, message.params);

--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -427,13 +427,6 @@ export class Backend extends BackendClient {
     return wsEndpoint + '?debug-controller';
   }
 
-  override rewriteWsHeaders(headers: Record<string, string>): Record<string, string> {
-    return {
-      ...headers,
-      'x-playwright-debug-controller': 'true' // Remove after v1.35
-    };
-  }
-
   override async initialize() {
     await this.send('initialize', { codegenId: 'playwright-test', sdkLanguage: 'javascript' });
     await this.send('setReportStateChanged', { enabled: true });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -194,9 +194,7 @@ export const test = baseTest.extend<TestFixtures, WorkerOptions>({
 export async function connectToSharedBrowser(vscode: VSCode) {
   await expect.poll(() => vscode.extensions[0].browserServerWSForTest()).toBeTruthy();
   const wsEndpoint = vscode.extensions[0].browserServerWSForTest();
-  return await chromium.connect(wsEndpoint, {
-    headers: { 'x-playwright-reuse-context': '1' }
-  });
+  return await chromium.connect(wsEndpoint);
 }
 
 export async function waitForPage(browser: Browser) {


### PR DESCRIPTION
VSCode's minimum Playwright version [is v1.38](https://github.com/microsoft/playwright-vscode/pull/487). These headers were removed in https://github.com/microsoft/playwright/pull/23215.