### PR TITLE
chore: allow buffer attachments

### DIFF
--- a/src/oopReporter.ts
+++ b/src/oopReporter.ts
@@ -42,7 +42,7 @@ class TeleReporter extends TeleReporterEmitter {
         console.log(message);
       };
     }
-    super(messageSink, { omitBuffers: true, omitOutput: true });
+    super(messageSink, { omitBuffers: false, omitOutput: true });
     this._hasSender = !!options?._send;
   }
 

--- a/src/upstream/teleEmitter.ts
+++ b/src/upstream/teleEmitter.ts
@@ -239,10 +239,11 @@ export class TeleReporterEmitter implements ReporterV2 {
 
   _serializeAttachments(attachments: reporterTypes.TestResult['attachments']): teleReceiver.JsonAttachment[] {
     return attachments.map(a => {
+      const { body, ...rest } = a;
       return {
-        ...a,
+        ...rest,
         // There is no Buffer in the browser, so there is no point in sending the data there.
-        base64: (a.body && !this._emitterOptions.omitBuffers) ? a.body.toString('base64') : undefined,
+        base64: (body && !this._emitterOptions.omitBuffers) ? body.toString('base64') : undefined,
       };
     });
   }


### PR DESCRIPTION
This is a remnant from copying this over from the UI. `omitBuffers` is useful when sending from Node.js to the Browser, because the browser doesn't have a good representation of `Buffer`. In the extension, we're sending from Node to Node though, so we can turn this on.

One might think this leads to slightly more memory usage - but there was a bug where we were *already* spreading in the `body` field into the JSONified output, so I wouldn't worry.