### PR TITLE
fix: move testIdAttributeName to config.use

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -129,7 +129,7 @@ export async function startBackend(vscode: vscodeTypes.VSCode, options: BackendS
   });
   serverProcess.stderr?.on('data', data => {
     if (options.dumpIO)
-      console.log('[server err]', data.toString());
+      process.stderr.write('[server err] ' + data.toString());
     options.errors.push(data.toString());
   });
   serverProcess.on('error', options.onError);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -203,7 +203,7 @@ export class Extension implements RunHooks {
         try {
           await this._settingsModel.showBrowser.set(true);
           await this._showBrowserForRecording(file, project);
-          await this._reusedBrowser.record(model);
+          await this._reusedBrowser.record(project);
         } finally {
           await this._settingsModel.showBrowser.set(showBrowser);
         }
@@ -213,7 +213,11 @@ export class Extension implements RunHooks {
         if (!model)
           return vscode.window.showWarningMessage(messageNoPlaywrightTestsFound);
 
-        await this._reusedBrowser.record(model);
+        const project = model.enabledProjects()[0];
+        if (!project)
+          return vscode.window.showWarningMessage(this._vscode.l10n.t(`Project is disabled in the Playwright sidebar.`));
+
+        await this._reusedBrowser.record(project);
       }),
       vscode.commands.registerCommand('pw.extension.command.toggleModels', async () => {
         this._settingsView.toggleModels();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,26 +198,26 @@ export class Extension implements RunHooks {
         if (!file)
           return;
 
-
+        const testIdAttributeName = project.project.use.testIdAttribute ?? project.model.config.testIdAttributeName;
         const showBrowser = this._settingsModel.showBrowser.get() ?? false;
         try {
           await this._settingsModel.showBrowser.set(true);
           await this._showBrowserForRecording(file, project);
-          await this._reusedBrowser.record(project);
+          await this._reusedBrowser.record(model, testIdAttributeName);
         } finally {
           await this._settingsModel.showBrowser.set(showBrowser);
         }
       }),
       vscode.commands.registerCommand('pw.extension.command.recordAtCursor', async () => {
+        let testIdAttributeName: string | undefined = undefined;
         const model = this._models.selectedModel();
         if (!model)
           return vscode.window.showWarningMessage(messageNoPlaywrightTestsFound);
-
         const project = model.enabledProjects()[0];
-        if (!project)
-          return vscode.window.showWarningMessage(this._vscode.l10n.t(`Project is disabled in the Playwright sidebar.`));
+        if (project)
+          testIdAttributeName = project.project.use.testIdAttribute ?? project.model.config.testIdAttributeName;
 
-        await this._reusedBrowser.record(project);
+        await this._reusedBrowser.record(model, testIdAttributeName);
       }),
       vscode.commands.registerCommand('pw.extension.command.toggleModels', async () => {
         this._settingsView.toggleModels();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,26 +198,20 @@ export class Extension implements RunHooks {
         if (!file)
           return;
 
-        const testIdAttributeName = project.project.use.testIdAttribute ?? project.model.config.testIdAttributeName;
         const showBrowser = this._settingsModel.showBrowser.get() ?? false;
         try {
           await this._settingsModel.showBrowser.set(true);
           await this._showBrowserForRecording(file, project);
-          await this._reusedBrowser.record(model, testIdAttributeName);
+          await this._reusedBrowser.record(model, project);
         } finally {
           await this._settingsModel.showBrowser.set(showBrowser);
         }
       }),
       vscode.commands.registerCommand('pw.extension.command.recordAtCursor', async () => {
-        let testIdAttributeName: string | undefined = undefined;
         const model = this._models.selectedModel();
         if (!model)
           return vscode.window.showWarningMessage(messageNoPlaywrightTestsFound);
-        const project = model.enabledProjects()[0];
-        if (project)
-          testIdAttributeName = project.project.use.testIdAttribute ?? project.model.config.testIdAttributeName;
-
-        await this._reusedBrowser.record(model, testIdAttributeName);
+        await this._reusedBrowser.record(model);
       }),
       vscode.commands.registerCommand('pw.extension.command.toggleModels', async () => {
         this._settingsView.toggleModels();

--- a/src/listTests.d.ts
+++ b/src/listTests.d.ts
@@ -23,7 +23,7 @@ export type ProjectConfigWithFiles = {
   testDir: string;
   use: {
     // Legacy attribute, this is now part of FullProject['use'].
-    // Remove once https://github.com/microsoft/playwright/commit/1af4e367f4a46323f3b5a013527b944fe3176203 is common.
+    // Remove once https://github.com/microsoft/playwright/commit/1af4e367f4a46323f3b5a013527b944fe3176203 is widely available.
     testIdAttribute?: string;
   };
   files: string[];

--- a/src/listTests.d.ts
+++ b/src/listTests.d.ts
@@ -21,7 +21,11 @@ import type { TestError } from './upstream/reporter';
 export type ProjectConfigWithFiles = {
   name: string;
   testDir: string;
-  use: { testIdAttribute?: string };
+  use: {
+    // Legacy attribute, this is now part of FullProject['use'].
+    // Remove once https://github.com/microsoft/playwright/commit/1af4e367f4a46323f3b5a013527b944fe3176203 is common.
+    testIdAttribute?: string;
+  };
   files: string[];
 };
 

--- a/src/playwrightTestTypes.ts
+++ b/src/playwrightTestTypes.ts
@@ -23,7 +23,7 @@ export type TestConfig = {
   cli: string;
   version: number;
   // Legacy attribute, this is now part of FullProject['use'].
-  // Remove once https://github.com/microsoft/playwright/commit/1af4e367f4a46323f3b5a013527b944fe3176203 is common.
+  // Remove once https://github.com/microsoft/playwright/commit/1af4e367f4a46323f3b5a013527b944fe3176203 is widely available.
   testIdAttributeName?: string;
 };
 

--- a/src/playwrightTestTypes.ts
+++ b/src/playwrightTestTypes.ts
@@ -22,6 +22,9 @@ export type TestConfig = {
   configFile: string;
   cli: string;
   version: number;
+  // Legacy attribute, this is now part of FullProject['use'].
+  // Remove once https://github.com/microsoft/playwright/commit/1af4e367f4a46323f3b5a013527b944fe3176203 is common.
+  testIdAttributeName?: string;
 };
 
 export type PlaywrightTestRunOptions = {

--- a/src/playwrightTestTypes.ts
+++ b/src/playwrightTestTypes.ts
@@ -22,7 +22,6 @@ export type TestConfig = {
   configFile: string;
   cli: string;
   version: number;
-  testIdAttributeName?: string;
 };
 
 export type PlaywrightTestRunOptions = {

--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -103,6 +103,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
       cwd,
       envProvider,
       errors,
+      dumpIO: false,
     });
     const backend = await backendServer.startAndConnect();
     if (!backend)
@@ -236,7 +237,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
     try {
       await this._backend?.setMode({
         mode: 'inspecting',
-        testIdAttributeName: selectedModel.enabledProjects()[0]?.project?.use?.testIdAttribute,
+        testIdAttributeName: selectedModel.enabledProjects()[0]?.project?.use?.testIdAttribute ?? selectedModel.config.testIdAttributeName,
       });
       this._recorderModeForTest = 'inspecting';
     } catch (e) {
@@ -318,7 +319,10 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
     ]);
 
     try {
-      await this._backend?.setMode({ mode: 'recording', testIdAttributeName: project.project.use.testIdAttribute });
+      await this._backend?.setMode({
+        mode: 'recording',
+        testIdAttributeName: project.project.use.testIdAttribute ?? project.model.config.testIdAttributeName,
+      });
       this._recorderModeForTest = 'recording';
     } catch (e) {
       showExceptionAsUserError(this._vscode, project.model, e as Error);

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -212,7 +212,6 @@ export class TestModel extends DisposableBase {
       for (const file of project.files)
         files.push(...await resolveSourceMap(file, this._fileToSources, this._sourceToFile));
       project.files = files;
-      this.config.testIdAttributeName = project.use?.testIdAttribute;
     }
 
     const projectsToKeep = new Set<string>();

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -212,6 +212,7 @@ export class TestModel extends DisposableBase {
       for (const file of project.files)
         files.push(...await resolveSourceMap(file, this._fileToSources, this._sourceToFile));
       project.files = files;
+      this.config.testIdAttributeName = project.use?.testIdAttribute;
     }
 
     const projectsToKeep = new Set<string>();


### PR DESCRIPTION
This fixes two things:

a) `Pick Locator` command was launched before a `ReusableBrowser` was launched via a test. This now uses the first project's `'testIdAttribute'` for it.
b) 'Record at cursor' was not wired up correctly for `'testIdAttribute'`. This now uses also the project's use `'testIdAttribute'` instead of the one from the config.

Both were using a bad `'testIdAttribute'`:  Before when you had e.g. a `testIdAttribute` configured on `project1`, it was overridden again by `project2`.

Fixes https://github.com/microsoft/playwright/issues/35881