### PR TITLE
test: fix flaky pick-selector.spec.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -900,6 +900,10 @@ test('test', async ({ page }) => {
     return this._reusedBrowser.browserServerWSEndpoint();
   }
 
+  recorderModeForTest() {
+    return this._reusedBrowser.recorderModeForTest();
+  }
+
   fireTreeItemSelectedForTest(testItem: vscodeTypes.TestItem | null) {
     this._treeItemSelected(testItem);
   }

--- a/tests/pick-selector.spec.ts
+++ b/tests/pick-selector.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { connectToSharedBrowser, expect, test, waitForPage } from './utils';
+import { connectToSharedBrowser, expect, test, waitForPage, waitForRecorderMode } from './utils';
 
 test('should pick locator and dismiss the toolbar', async ({ activate, overridePlaywrightVersion }) => {
   const { vscode } = await activate({
@@ -23,6 +23,7 @@ test('should pick locator and dismiss the toolbar', async ({ activate, overrideP
 
   const settingsView = vscode.webViews.get('pw.extension.settingsView')!;
   await settingsView.getByText('Pick locator').click();
+  await waitForRecorderMode(vscode, 'inspecting');
 
   const browser = await connectToSharedBrowser(vscode);
   const page = await waitForPage(browser);
@@ -49,6 +50,7 @@ test('should pick locator and dismiss the toolbar', async ({ activate, overrideP
 
   await page.click('x-pw-tool-item.pick-locator');
   await expect(page.locator('x-pw-tool-item.pick-locator')).toBeHidden();
+  await waitForRecorderMode(vscode, 'none');
 });
 
 test('should highlight locator on edit', async ({ activate }) => {
@@ -58,6 +60,7 @@ test('should highlight locator on edit', async ({ activate }) => {
 
   const settingsView = vscode.webViews.get('pw.extension.settingsView')!;
   await settingsView.getByText('Pick locator').click();
+  await waitForRecorderMode(vscode, 'inspecting');
 
   const browser = await connectToSharedBrowser(vscode);
   const page = await waitForPage(browser);
@@ -82,6 +85,7 @@ test('should copy locator to clipboard', async ({ activate }) => {
   const locatorsView = vscode.webViews.get('pw.extension.locatorsView')!;
   await locatorsView.getByRole('checkbox', { name: 'Copy on pick' }).check();
   await locatorsView.getByRole('button', { name: 'Pick locator' }).first().click();
+  await waitForRecorderMode(vscode, 'inspecting');
 
   const browser = await connectToSharedBrowser(vscode);
   const page = await waitForPage(browser);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -197,6 +197,10 @@ export async function connectToSharedBrowser(vscode: VSCode) {
   return await chromium.connect(wsEndpoint);
 }
 
+export async function waitForRecorderMode(vscode: VSCode, mode: string) {
+  await expect.poll(() => vscode.extensions[0].recorderModeForTest()).toBe(mode);
+}
+
 export async function waitForPage(browser: Browser, params?: BrowserContextOptions) {
   let pages: Page[] = [];
   await expect.poll(async () => {


### PR DESCRIPTION
There was a following race in the test:
- Click "pick locator" button.
- This engages the `ReusedBrowser` and calls `setRecorderMode('inspecting')` on it.
- Before the recorder engages, test connects to the reused browser.
- Test calls `newContextForReuse()`.
- `DebugController` also calls `newContextForReuse()` to set up the recorder.

Now there are two concurrent calls to `newContextForReuse()`, while the browser is not ready for such a thing.

It seems like the proper fix could be `newContextForReuse()` calls serialization on the browser side. It is unclear what kind of problems this could introduce. Meanwhile, fix the test by waiting for the recorder mode to engage before proceeding with the rest of the test.

Fixes #36400.