### PR TITLE
fix: don't run global setup for wrong project

### DIFF
--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -651,15 +651,18 @@ export class TestModel extends DisposableBase {
       return { locations: [] };
     const locations = new Set<string>();
     const testIds: string[] = [];
+    const enabledFiles = this.enabledFiles();
     for (const item of request.include) {
       const treeItem = upstreamTreeItem(item);
       if (treeItem.kind === 'group' && (treeItem.subKind === 'folder' || treeItem.subKind === 'file')) {
         const treeItemPath = treeItem.location.file + (treeItem.subKind === 'folder' ? path.sep : '');
-        for (const file of this.enabledFiles()) {
+        for (const file of enabledFiles) {
           if (file === treeItemPath || file.startsWith(treeItemPath))
             locations.add(treeItemPath);
         }
       } else {
+        if (!enabledFiles.has(treeItem.location.file))
+          continue;
         testIds.push(...collectTestIds(treeItem));
       }
     }


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/36757.

`TestModel.narrowDownLocations` doesn't filter out test IDs from a completely different model. That means for a `TestRunRequest` against an individual test, we currently send it to every Test Server. This didn't surface because issuing a testrun with a test ID that doesn't exist on a given test server is sort of a no-op, but it also means we execute global setup on config that isn't part of the test run. Not a huge deal, but definitely wrong.