### PR TITLE
chore: give actions right aria-disabled

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -53,6 +53,8 @@ export function createAction(action: ActionDescriptor, options?: { omitText?: bo
     });
   }
   label.setAttribute('role', 'button');
+  if (action.disabled)
+    label.setAttribute('aria-disabled', 'true');
   label.setAttribute('command', action.command);
   const svg = /** @type {HTMLElement} */(document.createElement('svg'));
   label.appendChild(svg);


### PR DESCRIPTION
We were adding `disabled=true` to the buttons parent, but not to the button itself. Discovered because my tests were clicking a disabled button without noticing.