### PR TITLE
chore: sort paths intuitively

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,7 +289,7 @@ export class Extension implements RunHooks {
 
     const configFiles = await this._vscode.workspace.findFiles('**/*playwright*.config.{ts,js,mts,mjs}', '**/node_modules/**');
     // findFiles returns results in a non-deterministic order - sort them to ensure consistent order when we enable the first model by default.
-    configFiles.sort((a, b) => uriToPath(a).localeCompare(uriToPath(b)));
+    configFiles.sort((a, b) => sortPaths(uriToPath(a), uriToPath(b)));
     for (const configFileUri of configFiles) {
       const configFilePath = uriToPath(configFileUri);
       // TODO: parse .gitignore
@@ -988,3 +988,15 @@ function ancestorProject(test: reporterTypes.TestCase): reporterTypes.FullProjec
 }
 
 const traceUrlSymbol = Symbol('traceUrl');
+
+/**
+ * sort paths intuitively.
+ * [/foo/bar, /foo, /foo/baz] -> [/foo, /foo/bar, /foo/baz]
+ */
+function sortPaths(a: string, b: string): number {
+  const aDepth = a.split(path.sep).length;
+  const bDepth = b.split(path.sep).length;
+  if (aDepth !== bDepth)
+    return aDepth - bDepth;
+  return a.localeCompare(b);
+}

--- a/tests/track-configs.spec.ts
+++ b/tests/track-configs.spec.ts
@@ -128,3 +128,16 @@ test('should show config loading errors', async ({ vscode, activate }) => {
   void testController.run(testItems);
   await expect.poll(() => vscode.window.activeTextEditor?.document.uri.toString()).toContain('playwright1.config.js');
 });
+
+test('should select root config by default', async ({ activate }) => {
+  const { vscode } = await activate({
+    'extension/playwright.config.ts': `module.exports = {};`,
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  const webView = vscode.webViews.get('pw.extension.settingsView')!;
+  await expect(webView.locator('body')).toMatchAriaSnapshot(`
+    - combobox "Select Playwright Config":
+      - option "playwright.config.ts"
+  `);
+});


### PR DESCRIPTION
I noticed that in the `playwright-mcp` repo, the extension selected `extension/playwright.config.ts` as the default config, instead of the more intuitive `playwright.config.ts`. By taking path depth into account when sorting, not just lexicals, we get a more intuitive ordering, and will select `playwright.config.ts` as the default.