### PR TITLE
chore(ui): hide projects section when there's a single project

### DIFF
--- a/src/settingsView.script.ts
+++ b/src/settingsView.script.ts
@@ -23,6 +23,13 @@ const unselectAllButton = document.getElementById('unselectAll') as HTMLAnchorEl
 const toggleModels = document.getElementById('toggleModels') as HTMLAnchorElement;
 
 function updateProjects(projects: ProjectEntry[]) {
+  const projectSelector = document.getElementById('project-selector')!;
+  if (projects.length < 2) {
+    projectSelector.style.display = 'none';
+    return;
+  }
+  projectSelector.style.display = 'flex';
+
   const projectsElement = document.getElementById('projects') as HTMLElement;
   projectsElement.textContent = '';
   for (const project of projects) {

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -223,18 +223,20 @@ function htmlForWebview(vscode: vscodeTypes.VSCode, extensionUri: vscodeTypes.Ur
           <select data-testid="models" id="models" title="${vscode.l10n.t('Select Playwright Config')}" ></select>
         </div>
       </div>
-      <h2 class="section-header">
-        ${vscode.l10n.t('PROJECTS')}
-        <div class="section-toolbar">
-          <a id="selectAll" role="button" title="${vscode.l10n.t('Select All')}">
-            <svg width="48" height="48" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M9 9H4v1h5V9z"/><path d="M7 12V7H6v5h1z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 3l1-1h7l1 1v7l-1 1h-2v2l-1 1H3l-1-1V6l1-1h2V3zm1 2h4l1 1v4h2V3H6v2zm4 1H3v7h7V6z"/></svg>
-          </a>
-          <a id="unselectAll" role="button" title="${vscode.l10n.t('Unselect All')}" hidden>
-            <svg width="48" height="48" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M9 9H4v1h5V9z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 3l1-1h7l1 1v7l-1 1h-2v2l-1 1H3l-1-1V6l1-1h2V3zm1 2h4l1 1v4h2V3H6v2zm4 1H3v7h7V6z"/></svg>
-          </a>
-        </div>
-      </h2>
-      <div data-testid="projects" id="projects" class="vbox"></div>
+      <div id="project-selector" class="vbox" style="display: none">
+        <h2 class="section-header">
+          ${vscode.l10n.t('PROJECTS')}
+          <div class="section-toolbar">
+            <a id="selectAll" role="button" title="${vscode.l10n.t('Select All')}">
+              <svg width="48" height="48" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M9 9H4v1h5V9z"/><path d="M7 12V7H6v5h1z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 3l1-1h7l1 1v7l-1 1h-2v2l-1 1H3l-1-1V6l1-1h2V3zm1 2h4l1 1v4h2V3H6v2zm4 1H3v7h7V6z"/></svg>
+            </a>
+            <a id="unselectAll" role="button" title="${vscode.l10n.t('Unselect All')}" hidden>
+              <svg width="48" height="48" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M9 9H4v1h5V9z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 3l1-1h7l1 1v7l-1 1h-2v2l-1 1H3l-1-1V6l1-1h2V3zm1 2h4l1 1v4h2V3H6v2zm4 1H3v7h7V6z"/></svg>
+            </a>
+          </div>
+        </h2>
+        <div data-testid="projects" id="projects" class="vbox"></div>
+      </div>
       <h2 class="section-header">${vscode.l10n.t('SETUP')}</h2>
       <div id="rareActions" class="vbox"></div>
       <h2 class="section-header">${vscode.l10n.t('SETTINGS')}</h2>

--- a/tests/project-tree.spec.ts
+++ b/tests/project-tree.spec.ts
@@ -161,3 +161,16 @@ test('should hide unchecked projects', async ({ activate }) => {
     -    [playwright.config.js [projectTwo] — disabled]
   `);
 });
+
+test('should hide project section when there is just one', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {
+      projects: [
+        { name: 'projectOne', testDir: 'tests1', },
+      ]
+    }`,
+  });
+
+  const webView = vscode.webViews.get('pw.extension.settingsView')!;
+  await expect(webView.getByRole('heading', { name: 'PROJECTS' })).not.toBeVisible();
+});


### PR DESCRIPTION
Some Playwright workspaces don't define projects, or don't define project names. We show a single project named `<untitled>`. That UI is confusing and wastes space. This PR hides the projects section when there's only a single project.