### PR TITLE
chore: yarn PnP support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,9 +350,9 @@ export class Extension implements RunHooks {
       return typeof entry[1] === 'string' ? entry : [entry[0], JSON.stringify(entry[1])];
     })) as NodeJS.ProcessEnv;
 
-    if (configFile && this._pnpFiles.has(configFile)) {
+    if (!env.NODE_OPTIONS && this._pnpFiles.has(configFile)) {
       const { pnpCJS, pnpLoader } = this._pnpFiles.get(configFile)!;
-      env.NODE_OPTIONS ??= '';
+      env.NODE_OPTIONS = '';
       if (pnpCJS)
         env.NODE_OPTIONS += ` --require ${pnpCJS}`;
       if (pnpLoader)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,14 +350,18 @@ export class Extension implements RunHooks {
       return typeof entry[1] === 'string' ? entry : [entry[0], JSON.stringify(entry[1])];
     })) as NodeJS.ProcessEnv;
 
-    if (!env.NODE_OPTIONS && this._pnpFiles.has(configFile)) {
-      const { pnpCJS, pnpLoader } = this._pnpFiles.get(configFile)!;
-      env.NODE_OPTIONS = '';
-      if (pnpCJS)
-        env.NODE_OPTIONS += ` --require ${pnpCJS}`;
-      if (pnpLoader)
-        env.NODE_OPTIONS += ` --experimental-loader ${pathToFileURL(pnpLoader)}`;
-    }
+    if (env.NODE_OPTIONS?.includes('.pnp.cjs') || env.NODE_OPTIONS?.includes('.pnp.js'))
+      return env;
+
+    if (!this._pnpFiles.has(configFile))
+      return env;
+
+    env.NODE_OPTIONS ??= '';
+    const { pnpCJS, pnpLoader } = this._pnpFiles.get(configFile)!;
+    if (pnpCJS)
+      env.NODE_OPTIONS += ` --require ${pnpCJS}`;
+    if (pnpLoader)
+      env.NODE_OPTIONS += ` --experimental-loader ${pathToFileURL(pnpLoader)}`;
 
     return env;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -369,8 +369,8 @@ export class Extension implements RunHooks {
   private async _detectPnp(configFileUri: vscodeTypes.Uri, root: string) {
     let dir = this._vscode.Uri.joinPath(configFileUri, '..');
     while (uriToPath(dir).length >= root.length) {
-      const pnpCjs = this._vscode.Uri.joinPath(configFileUri, '..', '.pnp.cjs');
-      const pnpLoader = this._vscode.Uri.joinPath(configFileUri, '..', '.pnp.loader.mjs');
+      const pnpCjs = this._vscode.Uri.joinPath(dir, '.pnp.cjs');
+      const pnpLoader = this._vscode.Uri.joinPath(dir, '.pnp.loader.mjs');
       const [pnpCjsExists, pnpLoaderExists] = await Promise.all([
         this._fileExists(pnpCjs),
         this._fileExists(pnpLoader)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -367,8 +367,9 @@ export class Extension implements RunHooks {
   }
 
   private async _detectPnp(configFileUri: vscodeTypes.Uri, root: string) {
-    let dir = this._vscode.Uri.joinPath(configFileUri, '..');
-    while (uriToPath(dir).length >= root.length) {
+    let dir = configFileUri;
+    while (uriToPath(dir) !== root) {
+      dir = this._vscode.Uri.joinPath(dir, '..');
       const pnpCjs = this._vscode.Uri.joinPath(dir, '.pnp.cjs');
       const pnpLoader = this._vscode.Uri.joinPath(dir, '.pnp.loader.mjs');
       const [pnpCjsExists, pnpLoaderExists] = await Promise.all([
@@ -385,15 +386,13 @@ export class Extension implements RunHooks {
         );
         return;
       }
-
-      dir = this._vscode.Uri.joinPath(dir, '..');
     }
   }
 
   private async _fileExists(uri: vscodeTypes.Uri) {
     try {
       const stat = await this._vscode.workspace.fs.stat(uri);
-      return !!(stat.type & this._vscode.FileType.File);
+      return !!(stat.type | this._vscode.FileType.File);
     } catch {
       return false;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { registerTerminalLinkProvider } from './terminalLinkProvider';
 import { RunHooks, TestConfig, ErrorContext } from './playwrightTestServer';
 import { ansi2html } from './ansi2html';
 import { LocatorsView } from './locatorsView';
+import { pathToFileURL } from 'url';
 
 const stackUtils = new StackUtils({
   cwd: '/ensure_absolute_paths'
@@ -355,7 +356,7 @@ export class Extension implements RunHooks {
       if (pnpCJS)
         env.NODE_OPTIONS += ` --require ${pnpCJS}`;
       if (pnpLoader)
-        env.NODE_OPTIONS += ` --experimental-loader ${pnpLoader}`;
+        env.NODE_OPTIONS += ` --experimental-loader ${pathToFileURL(pnpLoader)}`;
     }
 
     return env;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -353,7 +353,7 @@ export class Extension implements RunHooks {
       return typeof entry[1] === 'string' ? entry : [entry[0], JSON.stringify(entry[1])];
     })) as NodeJS.ProcessEnv;
 
-    if (env.NODE_OPTIONS?.includes('.pnp.cjs') || env.NODE_OPTIONS?.includes('.pnp.js'))
+    if (env.NODE_OPTIONS?.includes('.pnp.cjs') || env.NODE_OPTIONS?.includes('.pnp.loader.mjs'))
       return env;
 
     if (!this._pnpFiles.has(configFile))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -392,8 +392,8 @@ export class Extension implements RunHooks {
 
   private async _fileExists(uri: vscodeTypes.Uri) {
     try {
-      await this._vscode.workspace.fs.stat(uri);
-      return true;
+      const stat = await this._vscode.workspace.fs.stat(uri);
+      return !!(stat.type & this._vscode.FileType.File);
     } catch {
       return false;
     }

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -55,7 +55,7 @@ export interface RunHooks {
 export type PlaywrightTestOptions = {
   runHooks: RunHooks;
   isUnderTest: boolean;
-  envProvider: () => NodeJS.ProcessEnv;
+  envProvider: (configFile: string) => NodeJS.ProcessEnv;
   onStdOut: vscodeTypes.Event<string>;
 };
 
@@ -305,7 +305,7 @@ export class PlaywrightTestServer {
         env: {
           ...process.env,
           CI: this._options.isUnderTest ? undefined : process.env.CI,
-          ...this._options.envProvider(),
+          ...this._options.envProvider(this._model.config.configFile),
           // Reset VSCode's options that affect nested Electron.
           ELECTRON_RUN_AS_NODE: undefined,
           FORCE_COLOR: '1',
@@ -392,7 +392,7 @@ export class PlaywrightTestServer {
       cwd: paths.cwd,
       envProvider: () => {
         return {
-          ...this._options.envProvider(),
+          ...this._options.envProvider(this._model.config.configFile),
           FORCE_COLOR: '1',
           // Reset VSCode's options that affect nested Electron.
           ELECTRON_RUN_AS_NODE: undefined,

--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -30,7 +30,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
   private _cancelRecording: (() => void) | undefined;
   private _isRunningTests = false;
   private _insertedEditActionCount = 0;
-  private _envProvider: () => NodeJS.ProcessEnv;
+  private _envProvider: (configFile: string) => NodeJS.ProcessEnv;
   private _disposables: vscodeTypes.Disposable[] = [];
   private _pageCount = 0;
   private _onPageCountChangedEvent: vscodeTypes.EventEmitter<number>;
@@ -46,7 +46,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
   private _settingsModel: SettingsModel;
   private _recorderModeForTest: RecorderMode = 'none';
 
-  constructor(vscode: vscodeTypes.VSCode, settingsModel: SettingsModel, envProvider: () => NodeJS.ProcessEnv) {
+  constructor(vscode: vscodeTypes.VSCode, settingsModel: SettingsModel, envProvider: (configFile: string) => NodeJS.ProcessEnv) {
     this._vscode = vscode;
     this._envProvider = envProvider;
     this._onPageCountChangedEvent = new vscode.EventEmitter();
@@ -92,7 +92,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
     ];
     const cwd = config.workspaceFolder;
     const envProvider = () => ({
-      ...this._envProvider(),
+      ...this._envProvider(config.configFile),
       PW_CODEGEN_NO_INSPECTOR: '1',
       PW_EXTENSION_MODE: '1',
     });

--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -94,7 +94,7 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
     ];
     const cwd = model.config.workspaceFolder;
     const envProvider = () => ({
-      ...this._envProvider(config.configFile),
+      ...this._envProvider(model.config.configFile),
       PW_CODEGEN_NO_INSPECTOR: '1',
       PW_EXTENSION_MODE: '1',
     });

--- a/src/spawnTraceViewer.ts
+++ b/src/spawnTraceViewer.ts
@@ -22,13 +22,13 @@ import { TraceViewer } from './traceViewer';
 
 export class SpawnTraceViewer implements TraceViewer {
   private _vscode: vscodeTypes.VSCode;
-  private _envProvider: () => NodeJS.ProcessEnv;
+  private _envProvider: (configFile: string) => NodeJS.ProcessEnv;
   private _traceViewerProcess: ChildProcess | undefined;
   private _currentFile?: string;
   private _config: TestConfig;
   private _serverUrlPrefixForTest?: string;
 
-  constructor(vscode: vscodeTypes.VSCode, envProvider: () => NodeJS.ProcessEnv, config: TestConfig) {
+  constructor(vscode: vscodeTypes.VSCode, envProvider: (configFile: string) => NodeJS.ProcessEnv, config: TestConfig) {
     this._vscode = vscode;
     this._envProvider = envProvider;
     this._config = config;
@@ -65,7 +65,7 @@ export class SpawnTraceViewer implements TraceViewer {
       detached: true,
       env: {
         ...process.env,
-        ...this._envProvider(),
+        ...this._envProvider(this._config.configFile),
       },
     });
     this._traceViewerProcess = traceViewerProcess;

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -46,7 +46,7 @@ export type TestModelEmbedder = {
   settingsModel: SettingsModel;
   runHooks: RunHooks;
   isUnderTest: boolean;
-  envProvider: () => NodeJS.ProcessEnv;
+  envProvider: (configFile: string) => NodeJS.ProcessEnv;
   onStdOut: vscodeTypes.Event<string>;
   requestWatchRun: (files: string[], testItems: vscodeTypes.TestItem[]) => void;
 };

--- a/tests-integration/tests/baseTest.ts
+++ b/tests-integration/tests/baseTest.ts
@@ -91,18 +91,6 @@ export const test = base.extend<TestFixtures>({
         stdio: 'inherit',
         shell: true,
       });
-
-      if (packageManager === 'yarn-berry') {
-        await fs.promises.mkdir(path.join(projectPath, '.vscode'), { recursive: true });
-
-        // see https://github.com/microsoft/playwright/issues/18931.
-        // ideally, we'd support this by default
-        await fs.promises.writeFile(path.join(projectPath, '.vscode', 'settings.json'), JSON.stringify({
-          'playwright.env': {
-            'NODE_OPTIONS': '-r ./.pnp.cjs --experimental-loader ./.pnp.loader.mjs'
-          }
-        }));
-      }
       return projectPath;
     });
   },

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -923,7 +923,6 @@ export class VSCode {
   TestRunRequest = TestRunRequest;
   Uri = Uri;
   UIKind = UIKind;
-  FileType = FileType;
   commands: any = {};
   debug: Debug;
   languages: any = {};

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -89,13 +89,6 @@ export enum DiagnosticSeverity {
   Hint = 'Hint'
 }
 
-enum FileType {
-  Unknown = 0,
-  File = 1,
-  Directory = 2,
-  SymbolicLink = 64
-}
-
 type Diagnostic = {
   message: string;
   location: Location;
@@ -1198,19 +1191,6 @@ export class VSCode {
           return { defaultValue: false, globalValue: settings[scope + '.' + key] };
         },
       };
-    };
-
-    this.workspace.fs = {};
-    this.workspace.fs.stat = async (uri: Uri) => {
-      const stat = await fs.promises.stat(uri.fsPath);
-      let type = FileType.Unknown;
-      if (stat.isFile())
-        type = FileType.File;
-      if (stat.isDirectory())
-        type = FileType.Directory;
-      if (stat.isSymbolicLink())
-        type += FileType.SymbolicLink;
-      return { ...stat, type };
     };
 
     this.env.clipboard = {

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -1191,6 +1191,9 @@ export class VSCode {
       };
     };
 
+    this.workspace.fs = {};
+    this.workspace.fs.stat = (uri: Uri) => fs.promises.stat(uri.fsPath);
+
     this.env.clipboard = {
       writeText: async (text: string) => this._clipboardText = text,
       readText: async () => this._clipboardText,

--- a/tests/pnp.spec.ts
+++ b/tests/pnp.spec.ts
@@ -16,6 +16,7 @@
 
 import { enableConfigs, expect, test } from './utils';
 import fs from 'node:fs/promises';
+import path from 'node:path';
 
 test('should pick up .pnp.cjs file closest to config', async ({ activate }, testInfo) => {
   const pnpCjsOutfile = testInfo.outputPath('pnp-cjs.txt');
@@ -27,11 +28,11 @@ test('should pick up .pnp.cjs file closest to config', async ({ activate }, test
     'playwright.config.js': `module.exports = { testDir: 'tests' }`,
     '.pnp.cjs': `
       const fs = require("node:fs");
-      fs.writeFileSync("${pnpCjsOutfile}", "root");
+      fs.writeFileSync(${JSON.stringify(pnpCjsOutfile)}, "root");
     `,
     '.pnp.loader.mjs': `
       import fs from 'node:fs';
-      fs.copyFileSync("${esmLoaderInfile}", "${esmLoaderOutfile}");
+      fs.copyFileSync(${JSON.stringify(esmLoaderInfile)}, ${JSON.stringify(esmLoaderOutfile)});
     `,
     'tests/root.spec.ts': `
       import { test } from '@playwright/test';
@@ -41,14 +42,14 @@ test('should pick up .pnp.cjs file closest to config', async ({ activate }, test
     'foo/playwright.config.js': `module.exports = { testDir: 'tests' }`,
     'foo/.pnp.cjs': `
       const fs = require("node:fs");
-      fs.writeFileSync("${pnpCjsOutfile}", "foo");
+      fs.writeFileSync(${JSON.stringify(pnpCjsOutfile)}, "foo");
     `,
     'foo/tests/foo.spec.ts': `
       import { test } from '@playwright/test';
       test('should pass', async () => {});
     `,
   });
-  await enableConfigs(vscode, ['playwright.config.js', 'foo/playwright.config.js']);
+  await enableConfigs(vscode, ['playwright.config.js', `foo${path.sep}playwright.config.js`]);
 
   await expect(testController).toHaveTestTree(`
     -   foo

--- a/tests/pnp.spec.ts
+++ b/tests/pnp.spec.ts
@@ -59,7 +59,7 @@ test('should pick up .pnp.cjs file closest to config', async ({ activate }, test
   expect(testRun.renderLog()).toContain('passed');
   expect(await fs.readFile(pnpCjsOutfile, 'utf-8')).toBe('foo');
 
-  await workspaceFolder.addFile('apps/tests/playwright.config.js', `module.exports = { testDir: 'tests' }`)
+  await workspaceFolder.addFile('apps/tests/playwright.config.js', `module.exports = { testDir: 'tests' }`);
   await enableConfigs(vscode, [`apps${path.sep}tests${path.sep}playwright.config.js`, `foo${path.sep}playwright.config.js`]);
   await expect(testController).toHaveTestTree(`
     -   apps

--- a/tests/pnp.spec.ts
+++ b/tests/pnp.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './utils';
+import fs from 'node:fs/promises';
+
+test('should pick up .pnp.cjs', async ({ activate }, testInfo) => {
+  const outfile = testInfo.outputPath('output.txt');
+  const { testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    '.pnp.cjs': `
+      const fs = require("node:fs");
+      fs.writeFileSync("${outfile}", "foo");
+    `,
+    'tests/test-1.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async () => {});
+    `,
+  });
+
+  const testRun = await testController.run();
+  expect(testRun.renderLog()).toContain('passed');
+  expect(await fs.readFile(outfile, 'utf-8')).toBe('foo');
+});


### PR DESCRIPTION
I'm going through open source Playwright projects, and found a couple that use Yarn PnP or PNPM. I'd like to make sure that they work with the extension by default, but PnP currently doesn't. This PR implements the workaround from https://github.com/microsoft/playwright/issues/18931. PnP is complicated, so I'm expecting us to invite a ton of bugs with this. Let's take that complexity from our users and load it onto ourselves.