### PR TITLE
chore: reveal webview curtain only after init finishes

### DIFF
--- a/media/common.css
+++ b/media/common.css
@@ -161,6 +161,10 @@ body[data-vscode-theme-kind=vscode-dark] .combobox:hover {
   width: 100%;
 }
 
+.hidden {
+  display: none;
+}
+
 /* Locators view */
 
 .locators-view .section {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -276,6 +276,8 @@ export class Extension implements RunHooks {
     };
 
     await this._rebuildModels(false);
+    this._settingsView.reveal();
+
     fileSystemWatchers.map(w => w.onDidChange(rebuildModelForConfig));
     fileSystemWatchers.map(w => w.onDidCreate(rebuildModelForConfig));
     fileSystemWatchers.map(w => w.onDidDelete(rebuildModelForConfig));

--- a/src/settingsView.script.ts
+++ b/src/settingsView.script.ts
@@ -118,5 +118,7 @@ window.addEventListener('message', event => {
       updateProjects(configsMap.get(select.value).projects);
     });
     modelSelector.style.display = showModelSelector ? 'flex' : 'none';
+  } else if (method === 'reveal') {
+    document.body.classList.remove('hidden');
   }
 });


### PR DESCRIPTION
To prevent the UI from jumping around during initialisation, we put it behind a curtain until initialisation finishes.

TODO: write a test that uses a lock file to block playwright.config.mts from loading