### PR TITLE
test: unskip yarn-berry windows integration tests

### DIFF
--- a/tests-integration/tests/baseTest.ts
+++ b/tests-integration/tests/baseTest.ts
@@ -71,8 +71,6 @@ export const test = base.extend<TestFixtures>({
     }
   },
   createProject: async ({ createTempDir, packageManager }, use) => {
-    test.skip(process.platform === 'win32' && packageManager === 'yarn-berry');
-
     await use(async () => {
       // We want to be outside of the project directory to avoid already installed dependencies.
       const projectPath = await createTempDir();
@@ -87,7 +85,7 @@ export const test = base.extend<TestFixtures>({
       else if (packageManager === 'yarn-classic')
         command = 'yarn create playwright';
       else if (packageManager === 'yarn-berry')
-        command = 'yarn create playwright@latest';
+        command = 'yarn create playwright';
       spawnSync(`${command} --yes -- --quiet --browser=chromium --gha --install-deps`, {
         cwd: projectPath,
         stdio: 'inherit',


### PR DESCRIPTION
Otherwise it ends up in a

```
'C:\.tools\.npm-global\bin\create-playwright@latest' is not recognized as an internal or external command,
operable program or batch file.
error Command failed.
Exit code: 1
```