### PR TITLE
chore: drop "Running global setup" line

### DIFF
--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -165,7 +165,6 @@ export class PlaywrightTestServer {
 
     try {
       if (type === 'setup') {
-        testListener.onStdOut?.('\x1b[2mRunning global setup if any\u2026\x1b[0m\n');
         const { report, status } = await Promise.race([
           testServer.runGlobalSetup({}),
           new Promise<{ status: 'interrupted', report: [] }>(f => token.onCancellationRequested(() => f({ status: 'interrupted', report: [] }))),

--- a/src/upstream/teleEmitter.ts
+++ b/src/upstream/teleEmitter.ts
@@ -162,6 +162,8 @@ export class TeleReporterEmitter implements ReporterV2 {
       rootDir: config.rootDir,
       version: config.version,
       workers: config.workers,
+      globalSetup: config.globalSetup,
+      globalTeardown: config.globalTeardown,
     };
   }
 

--- a/src/upstream/teleReceiver.ts
+++ b/src/upstream/teleReceiver.ts
@@ -30,7 +30,7 @@ export type JsonStackFrame = { file: string, line: number, column: number };
 
 export type JsonStdIOType = 'stdout' | 'stderr';
 
-export type JsonConfig = Pick<reporterTypes.FullConfig, 'configFile' | 'globalTimeout' | 'maxFailures' | 'metadata' | 'rootDir' | 'version' | 'workers'>;
+export type JsonConfig = Pick<reporterTypes.FullConfig, 'configFile' | 'globalTimeout' | 'maxFailures' | 'metadata' | 'rootDir' | 'version' | 'workers' | 'globalSetup' | 'globalTeardown'>;
 
 export type JsonPattern = {
   s?: string;

--- a/tests/global-errors.spec.ts
+++ b/tests/global-errors.spec.ts
@@ -61,6 +61,7 @@ test('should report error in global setup (explicit)', async ({ activate }) => {
   });
 
   const testRun = await testController.run();
+  await expect(testRun).toHaveOutput(/Running global setup if any…/);
   await expect(testRun).toHaveOutput(/Error: expect\(received\)\.toBe\(expected\)/);
 
   await expect(vscode).toHaveConnectionLog([

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1052,7 +1052,6 @@ test('should produce output twice', async ({ activate }) => {
       started
       passed
     Output:
-    Running global setup if any…
 
 
     Running 1 test using 1 worker


### PR DESCRIPTION
This line was added as an unrelated change in https://github.com/microsoft/playwright-vscode/pull/478. It's printed on the first test run, but unconditionally. Users without plugins or global setup will still see it, and might be confused. I think it's better to leave it out - if the global setup file logs something, it'll be visible, otherwise it's fine to not see it.