### PR TITLE
test: toolbar and recording is dismissed by testrun

### DIFF
--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -968,7 +968,7 @@ export class VSCode {
   readonly webViews = new Map<string, Page>();
   readonly commandLog: string[] = [];
   readonly l10n = new L10n();
-  lastWithProgressData = undefined;
+  lastWithProgressData: any;
   private _hoverProviders: Map<string, HoverProvider> = new Map();
   readonly version: string;
   readonly connectionLog: any[] = [];
@@ -1111,6 +1111,7 @@ export class VSCode {
         report: (data: any) => this.lastWithProgressData = data,
       };
       await callback(progress, new CancellationTokenSource().token);
+      this.lastWithProgressData = 'finished';
     };
     this.window.showTextDocument = (document: TextDocument) => {
       const editor = new TextEditor(document);

--- a/tests/pick-selector.spec.ts
+++ b/tests/pick-selector.spec.ts
@@ -125,3 +125,24 @@ test('should pick locator and use the testIdAttribute from the config', async ({
   // TODO: remove as per TODO above.
   selectors.setTestIdAttribute('data-testid');
 });
+
+test('running test should dismiss the toolbar', async ({ activate, showBrowser }) => {
+  test.skip(!showBrowser);
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', () => {});
+    `,
+  });
+
+  const settingsView = vscode.webViews.get('pw.extension.settingsView')!;
+  await settingsView.getByRole('button', { name: 'Pick locator' }).click();
+  await waitForRecorderMode(vscode, 'inspecting');
+
+  const testRun = await testController.run();
+  await expect(testRun).toHaveOutput('passed');
+
+  await waitForRecorderMode(vscode, 'none');
+});


### PR DESCRIPTION
I broke this behaviour in https://github.com/microsoft/playwright-vscode/pull/668 without realising, so this PR adds tests.