### PR TITLE
fix: disable settings while tests are running

### DIFF
--- a/src/settingsModel.ts
+++ b/src/settingsModel.ts
@@ -106,6 +106,7 @@ export class SettingsModel extends DisposableBase {
 }
 
 export interface Setting<T> extends vscodeTypes.Disposable {
+  readonly settingName: string;
   readonly onChange: vscodeTypes.Event<T>;
   get(): T | undefined;
   set(value: T): Promise<void>;

--- a/src/settingsView.script.ts
+++ b/src/settingsView.script.ts
@@ -79,15 +79,16 @@ window.addEventListener('message', event => {
 
   const { method, params } = event.data;
   if (method === 'settings') {
-    for (const [key, value] of Object.entries(params.settings as Record<string, string | boolean>)) {
-      const input = document.querySelector('input[setting=' + key + ']') as HTMLInputElement;
+    for (const { name, value, disabled } of params.settings) {
+      const input = document.querySelector('input[setting=' + name + ']') as HTMLInputElement;
       if (input) {
         if (typeof value === 'boolean')
           input.checked = value;
         else
           input.value = value;
+        input.disabled = !!disabled;
       }
-      const select = document.querySelector('select[setting=' + key + ']') as HTMLSelectElement;
+      const select = document.querySelector('select[setting=' + name + ']') as HTMLSelectElement;
       if (select)
         select.value = value as string;
     }

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -52,7 +52,10 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
     this._reusedBrowser = reusedBrowser;
     this._extensionUri = extensionUri;
     this._disposables = [
-      reusedBrowser.onRunningTestsChanged(() => this._updateActions()),
+      reusedBrowser.onRunningTestsChanged(() => {
+        this._updateActions();
+        this._updateSettings();
+      }),
       reusedBrowser.onPageCountChanged(() => this._updateActions()),
       vscode.window.registerWebviewViewProvider('pw.extension.settingsView', this),
     ];
@@ -112,7 +115,35 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
   }
 
   private _updateSettings() {
-    void this._view!.webview.postMessage({ method: 'settings', params: { settings: this._settingsModel.json() } });
+    const settings = [
+      {
+        name: this._settingsModel.showBrowser.settingName,
+        value: this._settingsModel.showBrowser.get(),
+        disabled: this._reusedBrowser.isRunningTests(),
+      },
+      {
+        name: this._settingsModel.showTrace.settingName,
+        value: this._settingsModel.showTrace.get(),
+        disabled: this._reusedBrowser.isRunningTests(),
+      },
+      {
+        name: this._settingsModel.runGlobalSetupOnEachRun.settingName,
+        value: this._settingsModel.runGlobalSetupOnEachRun.get(),
+      },
+      {
+        name: this._settingsModel.updateSnapshots.settingName,
+        value: this._settingsModel.updateSnapshots.get(),
+      },
+      {
+        name: this._settingsModel.updateSourceMethod.settingName,
+        value: this._settingsModel.updateSourceMethod.get(),
+      },
+      {
+        name: this._settingsModel.pickLocatorCopyToClipboard.settingName,
+        value: this._settingsModel.pickLocatorCopyToClipboard.get(),
+      }
+    ];
+    void this._view!.webview.postMessage({ method: 'settings', params: { settings } });
   }
 
   private _updateActions() {


### PR DESCRIPTION
Otherwise 'Show browser' checkbox can change state to disabled but the browser is still running.