### PR TITLE
chore(reused browser): close after test run finishes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,13 +23,12 @@ import * as reporterTypes from './upstream/reporter';
 import { ReusedBrowser } from './reusedBrowser';
 import { SettingsModel } from './settingsModel';
 import { SettingsView } from './settingsView';
-import { TestModel, TestModelCollection, TestProject } from './testModel';
+import { RunHooks, TestModel, TestModelCollection, TestProject } from './testModel';
 import { configError, disabledProjectName as disabledProject, TestTree } from './testTree';
 import { NodeJSNotFoundError, getPlaywrightInfo, stripAnsi, stripBabelFrame, uriToPath } from './utils';
 import * as vscodeTypes from './vscodeTypes';
 import { WorkspaceChange, WorkspaceObserver } from './workspaceObserver';
 import { registerTerminalLinkProvider } from './terminalLinkProvider';
-import { RunHooks, ErrorContext } from './playwrightTestServer';
 import { ansi2html } from './ansi2html';
 import { LocatorsView } from './locatorsView';
 
@@ -133,8 +132,8 @@ export class Extension implements RunHooks {
     };
   }
 
-  async onDidRunTests(debug: boolean) {
-    await this._reusedBrowser.onDidRunTests(debug);
+  async onDidRunTests() {
+    await this._reusedBrowser.onDidRunTests();
   }
 
   reusedBrowserForTest(): ReusedBrowser {
@@ -662,7 +661,7 @@ export class Extension implements RunHooks {
     // 1.52
     if (attachment.contentType === 'application/json' && attachment.body) {
       try {
-        const errorContext = JSON.parse(attachment.body.toString()) as ErrorContext;
+        const errorContext: { pageSnapshot?: string } = JSON.parse(attachment.body.toString());
         if (errorContext.pageSnapshot)
           return `### Page Snapshot at Failure\n\n${errorContext.pageSnapshot}`; // cannot use ``` codeblocks, vscode markdown does not support it
       } catch {}

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -47,13 +47,7 @@ export type PlaywrightTestRunOptions = {
   updateSourceMethod?: 'overwrite' | 'patch' | '3way' | undefined;
 };
 
-export interface RunHooks {
-  onWillRunTests(model: TestModel, debug: boolean): Promise<{ connectWsEndpoint?: string }>;
-  onDidRunTests(debug: boolean): Promise<void>;
-}
-
 export type PlaywrightTestOptions = {
-  runHooks: RunHooks;
   isUnderTest: boolean;
   envProvider: () => NodeJS.ProcessEnv;
   onStdOut: vscodeTypes.Event<string>;
@@ -362,7 +356,6 @@ export class PlaywrightTestServer {
       if (!token.isCancellationRequested && debugTestServer && !debugTestServer.isClosed())
         await this._runGlobalHooksInServer(debugTestServer, 'teardown', reporter, token);
       debugTestServer?.close();
-      await this._options.runHooks.onDidRunTests(true);
     }
   }
 

--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -400,8 +400,8 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
     await this._startBackendIfNeeded(model);
   }
 
-  async onDidRunTests(debug: boolean) {
-    if (debug && !this._settingsModel.showBrowser.get()) {
+  async onDidRunTests() {
+    if (!this._settingsModel.showBrowser.get()) {
       this._stop();
     } else {
       if (!this._pageCount)

--- a/src/testModel.ts
+++ b/src/testModel.ts
@@ -25,7 +25,7 @@ import type { ConfigSettings, SettingsModel, WorkspaceSettings } from './setting
 import path from 'path';
 import { DisposableBase } from './disposableBase';
 import { MultiMap } from './multimap';
-import { PlaywrightTestRunOptions, PlaywrightTestServer, RunHooks, TestConfig } from './playwrightTestServer';
+import { PlaywrightTestRunOptions, PlaywrightTestServer, TestConfig } from './playwrightTestServer';
 import { upstreamTreeItem } from './testTree';
 import { collectTestIds } from './upstream/testTree';
 import { TraceViewer } from './traceViewer';
@@ -40,6 +40,11 @@ export type TestProject = {
   project: reporterTypes.FullProject;
   [kIsEnabled]: boolean;
 };
+
+export interface RunHooks {
+  onWillRunTests(model: TestModel, debug: boolean): Promise<{ connectWsEndpoint?: string }>;
+  onDidRunTests(): Promise<void>;
+}
 
 export type TestModelEmbedder = {
   context: vscodeTypes.ExtensionContext;
@@ -559,7 +564,7 @@ export class TestModel extends DisposableBase {
         return;
       await this._playwrightTest.runTests(request, options, reporter, token);
     } finally {
-      await this._embedder.runHooks.onDidRunTests(false);
+      await this._embedder.runHooks.onDidRunTests();
     }
   }
 
@@ -597,7 +602,7 @@ export class TestModel extends DisposableBase {
         return;
       await this._playwrightTest.debugTests(request, options, reporter, token);
     } finally {
-      await this._embedder.runHooks.onDidRunTests(false);
+      await this._embedder.runHooks.onDidRunTests();
     }
   }
 

--- a/tests/auto-close.spec.ts
+++ b/tests/auto-close.spec.ts
@@ -103,3 +103,31 @@ test('should auto-close after pick', async ({ activate }) => {
   const reusedBrowser = await vscode.extensions[0].reusedBrowserForTest();
   await expect.poll(() => !!reusedBrowser._backend).toBeFalsy();
 });
+
+test('should enact "Show Browser" setting change after test finishes', async ({ activate, createLatch }) => {
+  const latch = createLatch();
+
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+    'test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('should pass', async ({ page }) => {
+        await page.setContent('foo');
+        ${latch.blockingCode}
+      });
+    `
+  });
+
+  const runPromise = testController.run();
+
+  const reusedBrowser = vscode.extensions[0].reusedBrowserForTest();
+  await expect.poll(() => !!reusedBrowser._backend, 'wait until test started').toBeTruthy();
+
+  const webView = vscode.webViews.get('pw.extension.settingsView')!;
+  await webView.getByRole('checkbox', { name: 'Show Browser' }).uncheck();
+  await expect.poll(() => !!reusedBrowser._backend, 'contrary to setting change, browser stays open during test run').toBeTruthy();
+  latch.open();
+  await runPromise;
+
+  await expect.poll(() => !!reusedBrowser._backend, 'after test run, setting change is honored').toBeFalsy();
+});


### PR DESCRIPTION
Unchecking "Show Browser" during a test run changes the setting in VS Code's store, but then shows a warning and doesn't actually stop the browser server:

https://github.com/microsoft/playwright-vscode/blob/6663081da3e1c925d6a46764796acb422092abcc/src/reusedBrowser.ts#L426-L431

On the next run, the browser server continues to be used, even. This is surprising behaviour. We shouldn't take away the browser server from an ongoing test run, but at least we can stop it afterwards. That's what his PR does, plus some cleanup.