### PR TITLE
Revert "fix: disable settings while tests are running"

### DIFF
--- a/src/settingsModel.ts
+++ b/src/settingsModel.ts
@@ -106,7 +106,6 @@ export class SettingsModel extends DisposableBase {
 }
 
 export interface Setting<T> extends vscodeTypes.Disposable {
-  readonly settingName: string;
   readonly onChange: vscodeTypes.Event<T>;
   get(): T | undefined;
   set(value: T): Promise<void>;

--- a/src/settingsView.script.ts
+++ b/src/settingsView.script.ts
@@ -126,20 +126,17 @@ window.addEventListener('message', event => {
 
   const { method, params } = event.data;
   if (method === 'settings') {
-    for (const { name, value, disabled } of params.settings) {
-      const input = document.querySelector('input[setting=' + name + ']') as HTMLInputElement;
+    for (const [key, value] of Object.entries(params.settings as Record<string, string | boolean>)) {
+      const input = document.querySelector('input[setting=' + key + ']') as HTMLInputElement;
       if (input) {
         if (typeof value === 'boolean')
           input.checked = value;
         else
           input.value = value;
-        input.disabled = !!disabled;
       }
-      const select = document.querySelector('select[setting=' + name + ']') as HTMLSelectElement;
-      if (select) {
+      const select = document.querySelector('select[setting=' + key + ']') as HTMLSelectElement;
+      if (select)
         select.value = value as string;
-        select.disabled = !!disabled;
-      }
     }
   } else if (method === 'actions') {
     actionsElement.textContent = '';

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -53,10 +53,7 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
     this._reusedBrowser = reusedBrowser;
     this._extensionUri = extensionUri;
     this._disposables = [
-      reusedBrowser.onRunningTestsChanged(() => {
-        this._updateActions();
-        this._updateSettings();
-      }),
+      reusedBrowser.onRunningTestsChanged(() => this._updateActions()),
       reusedBrowser.onPageCountChanged(() => {
         this._updateActions();
         this._updateBrowsers();
@@ -121,35 +118,7 @@ export class SettingsView extends DisposableBase implements vscodeTypes.WebviewV
   }
 
   private _updateSettings() {
-    const settings = [
-      {
-        name: this._settingsModel.showBrowser.settingName,
-        value: this._settingsModel.showBrowser.get(),
-        disabled: this._reusedBrowser.isRunningTests(),
-      },
-      {
-        name: this._settingsModel.showTrace.settingName,
-        value: this._settingsModel.showTrace.get(),
-        disabled: this._reusedBrowser.isRunningTests(),
-      },
-      {
-        name: this._settingsModel.runGlobalSetupOnEachRun.settingName,
-        value: this._settingsModel.runGlobalSetupOnEachRun.get(),
-      },
-      {
-        name: this._settingsModel.updateSnapshots.settingName,
-        value: this._settingsModel.updateSnapshots.get(),
-      },
-      {
-        name: this._settingsModel.updateSourceMethod.settingName,
-        value: this._settingsModel.updateSourceMethod.get(),
-      },
-      {
-        name: this._settingsModel.pickLocatorCopyToClipboard.settingName,
-        value: this._settingsModel.pickLocatorCopyToClipboard.get(),
-      }
-    ];
-    void this._view!.webview.postMessage({ method: 'settings', params: { settings } });
+    void this._view!.webview.postMessage({ method: 'settings', params: { settings: this._settingsModel.json() } });
   }
 
   private _updateActions() {

--- a/tests/auto-close.spec.ts
+++ b/tests/auto-close.spec.ts
@@ -124,13 +124,7 @@ test('should enact "Show Browser" setting change after test finishes', async ({ 
   await expect.poll(() => !!reusedBrowser._backend, 'wait until test started').toBeTruthy();
 
   const webView = vscode.webViews.get('pw.extension.settingsView')!;
-
-  const checkbox = await webView.getByRole('checkbox', { name: 'Show Browser' });
-  await expect(checkbox).toBeDisabled();
-  // Normally checkbox will be disabled when the tests start running. Emulate racy
-  // condition when the checkbox is still enabled.
-  await checkbox.evaluate(checkbox => (checkbox as HTMLInputElement).disabled = false);
-  await checkbox.uncheck();
+  await webView.getByRole('checkbox', { name: 'Show Browser' }).uncheck();
   await expect.poll(() => !!reusedBrowser._backend, 'contrary to setting change, browser stays open during test run').toBeTruthy();
   latch.open();
   await runPromise;

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1293,27 +1293,3 @@ http.createServer((req, res) => {
   const testRun = await testController.run();
   expect(testRun.renderLog({ output: true })).toContain('passed');
 });
-
-test('should disable browser settings while tests are running', async ({ activate, createLatch, showBrowser }) => {
-  test.skip(!showBrowser);
-
-  const latch = createLatch();
-
-  const { vscode, testController } = await activate({
-    'playwright.config.js': `module.exports = {}`,
-    'test.spec.ts': `
-      import { test } from '@playwright/test';
-      test('blocking test', async () => ${latch.blockingCode});
-    `,
-  });
-
-  const webView = vscode.webViews.get('pw.extension.settingsView')!;
-  const showBrowserButton = webView.getByLabel('Show browser');
-
-  await expect(showBrowserButton).toBeEnabled();
-  const runPromise = testController.run();
-  await expect(showBrowserButton).toBeDisabled();
-  latch.open();
-  await runPromise;
-  await expect(showBrowserButton).toBeEnabled();
-});


### PR DESCRIPTION
Reverts microsoft/playwright-vscode#683

Conditional UI can be confusing, and https://github.com/microsoft/playwright-vscode/pull/685 should already help the specific usecase. cc @yury-s