### PR TITLE
chore: dont enable just setup project by default

### DIFF
--- a/src/listTests.d.ts
+++ b/src/listTests.d.ts
@@ -27,6 +27,8 @@ export type ProjectConfigWithFiles = {
     testIdAttribute?: string;
   };
   files: string[];
+  dependencies: string[];
+  teardown?: string;
 };
 
 export type ConfigListFilesReport = {

--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -99,6 +99,8 @@ export class PlaywrightTestServer {
           result.projects.push({
             name: project.name,
             testDir: project.testDir,
+            dependencies: project.dependencies,
+            teardown: project.teardown,
             use: project.use || {},
             files,
           });

--- a/tests/project-setup.spec.ts
+++ b/tests/project-setup.spec.ts
@@ -49,7 +49,12 @@ const testsWithSetup = {
 
 test('should run setup and teardown projects (1)', async ({ activate }) => {
   const { vscode, testController } = await activate(testsWithSetup);
-  await enableProjects(vscode, ['setup', 'teardown', 'test']);
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.ts
+    [x] setup
+    [x] test
+    [x] teardown
+  `);
   const testRun = await testController.run();
 
   await expect(testController).toHaveTestTree(`
@@ -114,7 +119,12 @@ test('should run setup and teardown projects (3)', async ({ activate }) => {
 
 test('should run part of the setup only', async ({ activate }) => {
   const { vscode, testController } = await activate(testsWithSetup);
-  await enableProjects(vscode, ['setup', 'teardown', 'test']);
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.ts
+    [x] setup
+    [x] test
+    [x] teardown
+  `);
 
   await testController.expandTestItems(/setup.ts/);
   const testItems = testController.findTestItems(/setup/);
@@ -131,7 +141,12 @@ test('should run part of the setup only', async ({ activate }) => {
 
 test('should run setup and teardown for test', async ({ activate }) => {
   const { vscode, testController } = await activate(testsWithSetup);
-  await enableProjects(vscode, ['setup', 'teardown', 'test']);
+  await expect(vscode).toHaveProjectTree(`
+    config: playwright.config.ts
+    [x] setup
+    [x] test
+    [x] teardown
+  `);
 
   await testController.expandTestItems(/test.ts/);
   const testItems = testController.findTestItems(/test/);


### PR DESCRIPTION
While going through VS Code extension feedback, I came across a review linking to https://github.com/microsoft/playwright/issues/35731. This PR resolves that.

When opening a Playwright project for the first time, we enable the *first* project in the project list. In the case of this issue, that's a `setup` project that's not useful alone. Putting the setup project first is [what we recommend in our docs](https://playwright.dev/docs/test-global-setup-teardown#setup), so I reckon this isn't the only user facing this issue.

To fix this, i've updated the logic so that we pick the first root project and all of its dependents.