### PR TITLE
Record start url support

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,13 @@
           ],
           "default": "3way",
           "description": "%configuration.playwright.updateSourceMethod%"
+        },
+        "playwright.recordStartUrl": {
+          "type": "string",
+          "default": "",
+          "pattern": "^$|^[a-zA-Z]+://",
+          "patternErrorMessage": "%configuration.playwright.recordStartUrl.patternErrorMessage%",
+          "description": "%configuration.playwright.recordStartUrl%"
         }
       }
     },

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -23,6 +23,8 @@
   "configuration.playwright.pickLocatorCopyToClipboard": "Markierten Locator automatisch in die Zwischenablage kopieren.",
   "configuration.playwright.updateSnapshots": "Snapshots aktualisieren",
   "configuration.playwright.updateSourceMethod": "Quellmethode aktualisieren",
+  "configuration.playwright.recordStartUrl": "URL, zu der beim Aufzeichnen eines neuen Tests navigiert wird.",
+  "configuration.playwright.recordStartUrl.patternErrorMessage": "URL muss ein Schema enthalten, z.B. https://example.com",
   "views.test.pw.extension.locatorsView": "Locator",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -23,6 +23,8 @@
   "configuration.playwright.pickLocatorCopyToClipboard": "Copier automatiquement le locator sélectionné dans le presse-papiers.",
   "configuration.playwright.updateSnapshots": "Mettre à jour les captures d'écran",
   "configuration.playwright.updateSourceMethod": "Mettre à jour la méthode source",
+  "configuration.playwright.recordStartUrl": "URL vers laquelle naviguer lors de l'enregistrement d'un nouveau test.",
+  "configuration.playwright.recordStartUrl.patternErrorMessage": "L'URL doit inclure un schéma, par ex. https://example.com",
   "views.test.pw.extension.locatorsView": "Localisateurs",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -23,6 +23,8 @@
   "configuration.playwright.pickLocatorCopyToClipboard": "Copia automaticamente il locator selezionato negli appunti.",
   "configuration.playwright.updateSnapshots": "Aggiorna gli snapshot",
   "configuration.playwright.updateSourceMethod": "Aggiorna il metodo sorgente",
+  "configuration.playwright.recordStartUrl": "URL a cui navigare durante la registrazione di un nuovo test.",
+  "configuration.playwright.recordStartUrl.patternErrorMessage": "L'URL deve includere lo schema, ad es. https://example.com",
   "views.test.pw.extension.locatorsView": "Localizzatori",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,6 +23,8 @@
   "configuration.playwright.pickLocatorCopyToClipboard": "Automatically copy picked locator to clipboard.",
   "configuration.playwright.updateSnapshots": "Update snapshots",
   "configuration.playwright.updateSourceMethod": "Update source method",
+  "configuration.playwright.recordStartUrl": "URL to navigate to when recording a new test.",
+  "configuration.playwright.recordStartUrl.patternErrorMessage": "URL must include a scheme, e.g. https://example.com",
   "views.test.pw.extension.locatorsView": "Locators",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -23,6 +23,8 @@
   "configuration.playwright.pickLocatorCopyToClipboard": "自动将选中的定位器复制到剪贴板",
   "configuration.playwright.updateSnapshots": "更新快照",
   "configuration.playwright.updateSourceMethod": "更新源方法",
+  "configuration.playwright.recordStartUrl": "录制新测试时要导航到的 URL。",
+  "configuration.playwright.recordStartUrl.patternErrorMessage": "URL 必须包含协议，例如 https://example.com",
   "views.test.pw.extension.locatorsView": "定位器",
   "views.test.pw.extension.settingsView": "Playwright"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -813,9 +813,14 @@ export class Extension implements RunHooks {
     if (!file)
       return;
 
+    let gotoLine = '';
+    const recordStartUrl = this._vscode.workspace.getConfiguration('playwright').get<string>('recordStartUrl', '').trim() || undefined;
+    if (recordStartUrl)
+      gotoLine = `\n  await page.goto(${JSON.stringify(recordStartUrl)});`;
+
     await fs.promises.writeFile(file, `import { test, expect } from '@playwright/test';
 
-test('test', async ({ page }) => {
+test('test', async ({ page }) => {${gotoLine}
   // Recording...
 });`);
 
@@ -824,7 +829,8 @@ test('test', async ({ page }) => {
 
     const document = await this._vscode.workspace.openTextDocument(file);
     const editor = await this._vscode.window.showTextDocument(document);
-    editor.selection = new this._vscode.Selection(new this._vscode.Position(3, 2), new this._vscode.Position(3, 2 + '// Recording...'.length));
+    const recordingLine = recordStartUrl ? 4 : 3;
+    editor.selection = new this._vscode.Selection(new this._vscode.Position(recordingLine, 2), new this._vscode.Position(recordingLine, 2 + '// Recording...'.length));
 
     return file;
   }

--- a/tests/codegen.spec.ts
+++ b/tests/codegen.spec.ts
@@ -73,6 +73,26 @@ test('test', async ({ page }) => {
   }]);
 });
 
+test('should navigate to recordStartUrl when recording', async ({ activate }) => {
+  test.slow();
+
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = {}`,
+  });
+
+  const configuration = vscode.workspace.getConfiguration('playwright');
+  configuration.update('recordStartUrl', 'https://example.com');
+
+  const webView = vscode.webViews.get('pw.extension.settingsView')!;
+  await webView.getByText('Record new').click();
+  await expect.poll(() => vscode.lastWithProgressData, { timeout: 0 }).toEqual({ message: 'recording\u2026' });
+
+  const browser = await connectToSharedBrowser(vscode);
+  const page = await waitForPage(browser);
+  // The test template includes page.goto() which navigates before recording starts.
+  await expect.poll(() => page.url()).toBe('https://example.com/');
+});
+
 test('running test should stop the recording', async ({ activate, showBrowser }) => {
   test.skip(!showBrowser);
 


### PR DESCRIPTION
**Summary**
  - Adds a playwright.recordStartUrl VS Code setting that configures a URL to navigate to when using "Record new"
  - When set, the generated test template includes await page.goto(url) which navigates the browser before recording starts
  - Includes URL scheme validation (http://, https://, file://, etc.) with a localized error message
  - When empty (default), behavior is unchanged — recording starts on about:blank

**Motivation**
Currently, clicking "Record new" opens the browser at about:blank and the user must manually navigate to their application. The CLI equivalent (playwright codegen <url>) supports a URL argument, but the VS Code extension had no equivalent. This setting closes that gap.

**How it works**
The URL is embedded as page.goto() in the generated test template. The test runs before recording starts, navigating the browser in-place — no subprocess or CDP manipulation needed.