### PR TITLE
chore: rebase tests for richer error context

### DIFF
--- a/.claude/skills/roll-playwright.md
+++ b/.claude/skills/roll-playwright.md
@@ -1,0 +1,37 @@
+---
+name: roll-playwright
+description: Roll @playwright/test to the latest next version, build, test, and push a PR branch
+user_invocable: true
+---
+
+# Roll Playwright Dependency
+
+Follow these steps in order. Stop and report to the user if any step fails.
+
+## 1. Get the latest version
+
+Run `npm info @playwright/test@next version` to get the latest available next version. Save this version string for later.
+
+## 2. Update package.json
+
+Update the `@playwright/test` version in `devDependencies` in `package.json` to the version from step 1.
+
+## 3. Install dependencies
+
+Run `npm i` to update `package-lock.json`.
+
+## 4. Build
+
+Run `npm run build`. If this fails, stop and report the error.
+
+## 5. Test
+
+Run `npm run test`. If this fails, stop and report the error.
+
+## 6. Create branch, commit, and push
+
+- Create a new branch named `roll-pwt-<version>` (e.g. `roll-pwt-1.58.2-beta-1770322573000`)
+- Stage `package.json` and `package-lock.json`
+- Commit with message: `chore: roll playwright to <version>`
+- Do NOT add Co-Authored-By to the commit message
+- Push the branch to origin

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.23.2",
-        "@playwright/test": "1.58.1-beta-1769785134000",
+        "@playwright/test": "1.59.0-alpha-1773598190000",
         "@types/babel__core": "^7.20.3",
         "@types/babel__helper-plugin-utils": "^7.10.2",
         "@types/babel__traverse": "^7.20.3",
@@ -1470,13 +1470,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.1-beta-1769785134000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1-beta-1769785134000.tgz",
-      "integrity": "sha512-DasANd29FfRGhK5Jay7NGHBQYRnLCIUF6EnDO+OftIgNQdBXNeDIA8M84I/aZKqpi3jDOqAU+bZChOqEiLyCtA==",
+      "version": "1.59.0-alpha-1773598190000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.0-alpha-1773598190000.tgz",
+      "integrity": "sha512-JJ+tMHTAhK2DHgsaNeadz/83xoOvzicsWop8w6A2RUzRwStBMmzvli+vyBtJ7qIK9ybGTX7OcZvDwDjE8HaIAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.1-beta-1769785134000"
+        "playwright": "1.59.0-alpha-1773598190000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5809,13 +5809,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.1-beta-1769785134000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1-beta-1769785134000.tgz",
-      "integrity": "sha512-mmKt9NqkyjeRobiM4cf4CLaoP2p7XCb4t372JemLjjBbytuUGYSg5zwzSxim/jSOuc35t/n+uomQTkCgYiESlQ==",
+      "version": "1.59.0-alpha-1773598190000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0-alpha-1773598190000.tgz",
+      "integrity": "sha512-DRWQxcLaT4uiEohRTGO9eicPI2TErjc2bpM7vFmEtR5i3PFrgYwx/7pKA6qj3XA3F6AGX9y9O2wsqeinqEjsEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.1-beta-1769785134000"
+        "playwright-core": "1.59.0-alpha-1773598190000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5828,9 +5828,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.1-beta-1769785134000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1-beta-1769785134000.tgz",
-      "integrity": "sha512-QMy2+mWu70nY7Ip/If5bY/LJ5/DDL+i3AXrEDj6K4IT5X0I5oOmbrZ1aH0djnn39FqQQ5/wFR+8RXRaewO5wlw==",
+      "version": "1.59.0-alpha-1773598190000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0-alpha-1773598190000.tgz",
+      "integrity": "sha512-9TSjHfBP6e5+V9UScIH2q4CrRMPei52K78uTLw4xqj+lQ6U7LVyyMVkFjNRjMXqBg+exeLcG9HN7Gd+s5gprNg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.2",
-    "@playwright/test": "1.58.1-beta-1769785134000",
+    "@playwright/test": "1.59.0-alpha-1773598190000",
     "@types/babel__core": "^7.20.3",
     "@types/babel__helper-plugin-utils": "^7.10.2",
     "@types/babel__traverse": "^7.20.3",

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -509,7 +509,10 @@ export class TestRun {
       result.push('  Output:');
       result.push(...this._renderOutput());
     }
-    return trimLog(result.join(`\n${indent}`)) + `\n${indent}`;
+    let log = trimLog(result.join(`\n${indent}`)) + `\n${indent}`;
+    // Strip Playwright's "Context for AI" details block as it contains absolute paths.
+    log = log.replace(/\n?\s*<br><br><details><summary>Context for AI<\/summary>[\s\S]*?<\/details>/g, '');
+    return log;
   }
 
   renderOutput(): string {

--- a/tests/run-tests.spec.ts
+++ b/tests/run-tests.spec.ts
@@ -1168,7 +1168,8 @@ test('should provide page snapshot to copilot', async ({ activate }) => {
   });
 
   const testRun = await testController.run();
-  const log = testRun.renderLog({ messages: true });
+  const allMessages = [...testRun.entries.values()].flat().flatMap(e => e.messages ?? []);
+  const log = allMessages.map(m => m.message.render()).join('\n');
   expect(log).toContain(`<details><summary>Context for AI</summary>`);
   expect(log).toContain(`# Page snapshot`);
   expect(log).toContain(`- button "click me"`);


### PR DESCRIPTION
## Summary
- Strip "Context for AI" block in test renderLog() to avoid absolute path mismatches
- Roll @playwright/test to 1.59.0-alpha