### PR TITLE
test: cover ESM-only dependency discovery

### DIFF
--- a/tests/list-tests.spec.ts
+++ b/tests/list-tests.spec.ts
@@ -83,6 +83,44 @@ test('should list tests for visible editors', async ({ activate }) => {
   ]);
 });
 
+test('should list tests when they import local modules with ESM-only package dependencies', async ({ activate }) => {
+  const { testController } = await activate({
+    'package.json': JSON.stringify({ type: 'module' }),
+    'playwright.config.js': `
+      export default { testDir: 'tests' };
+    `,
+    'node_modules/foo-pkg/package.json': JSON.stringify({
+      name: 'foo-pkg',
+      type: 'module',
+      exports: {
+        '.': './index.js',
+      },
+    }),
+    'node_modules/foo-pkg/index.js': `
+      export const label = 'Button';
+    `,
+    'src/utils.ts': `
+      import { label } from 'foo-pkg';
+      export { label };
+    `,
+    'tests/test.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      import { label } from '../src/utils.js';
+
+      test('one', async () => {
+        expect(label).toBe('Button');
+      });
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+        -   one [4:0]
+  `);
+});
+
 test('should list suits', async ({ activate }) => {
   const { testController } = await activate({
     'playwright.config.js': `module.exports = { testDir: 'tests' }`,


### PR DESCRIPTION
Refs microsoft/playwright#39902.

## Summary
- add a VS Code extension integration test for a workspace that uses ESM config and imports a local module that depends on an ESM-only package
- verify test discovery still lists the spec in the extension tree for that setup

## Testing
- `npx eslint tests/list-tests.spec.ts`
- `$env:PLAYWRIGHT_BROWSERS_PATH=''C:\Users\raash\Desktop\open-source-contribution\.tmp-contributor-03-pw-browsers''; npx playwright test tests/list-tests.spec.ts -g "should list tests when they import local modules with ESM-only package dependencies"`