### PR TITLE
fix(extension): clamp Position character to avoid negative values

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1028,7 +1028,7 @@ test('test', async ({ page }) => {
   }
 
   private _asPosition(location: { line: number, column: number }): vscodeTypes.Position {
-    return new this._vscode.Position(Math.max(location.line - 1, 0), location.column - 1);
+    return new this._vscode.Position(Math.max(location.line - 1, 0), Math.max(location.column - 1, 0));
   }
 
   private _asLocation(location: reporterTypes.Location): vscodeTypes.Location {
@@ -1096,7 +1096,7 @@ function parseStack(vscode: vscodeTypes.VSCode, stack: string): vscodeTypes.Test
     result.push(new vscode.TestMessageStackFrame(
         frame.method || '',
         vscode.Uri.file(frame.file),
-        new vscode.Position(Math.max(frame.line - 1, 0), frame.column - 1)));
+        new vscode.Position(Math.max(frame.line - 1, 0), Math.max(frame.column - 1, 0))));
   }
   return result;
 }

--- a/src/testTree.ts
+++ b/src/testTree.ts
@@ -226,7 +226,7 @@ export class TestTree extends DisposableBase {
         item.description = `${path.relative(model.config.workspaceFolder, normalizePath(model.config.configFile))} — ${message}`;
         item.sortText = 'z' + errorId;
         if (error.location) {
-          const position = new this._vscode.Position(Math.max(error.location.line - 1, 0), error.location.column - 1);
+          const position = new this._vscode.Position(Math.max(error.location.line - 1, 0), Math.max(error.location.column - 1, 0));
           item.range = new this._vscode.Range(position, position);
         }
         (item as any)[configErrorSymbol] = error;

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -75,7 +75,12 @@ export enum ColorThemeKind {
 }
 
 class Position {
-  constructor(readonly line: number, readonly character: number) {}
+  constructor(readonly line: number, readonly character: number) {
+    if (line < 0)
+      throw new Error('Illegal argument: line must be non-negative');
+    if (character < 0)
+      throw new Error('Illegal argument: character must be non-negative');
+  }
 
   toString() {
     return `${this.line}:${this.character}`;

--- a/tests/problems.spec.ts
+++ b/tests/problems.spec.ts
@@ -90,3 +90,21 @@ test('should update diagnostics on file change', async ({ activate }) => {
   `);
   await expect.poll(() => vscode.diagnosticsCollections[0]._entries.size).toBe(0);
 });
+
+test('should not throw on error location with column 0', async ({ activate }) => {
+  const { vscode } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+  });
+
+  // Some Playwright errors reach the extension with column 0 when the
+  // originating stack frame has no column info. VSCode's Position constructor
+  // rejects negative characters, so `column - 1` must be clamped at 0.
+  expect(() => new vscode.Position(0, -1)).toThrow(/character must be non-negative/);
+
+  const extension: any = vscode.extensions[0];
+  const position = extension._asPosition({ line: 5, column: 0 });
+  expect({ line: position.line, character: position.character }).toEqual({ line: 4, character: 0 });
+
+  const topOfFile = extension._asPosition({ line: 0, column: 0 });
+  expect({ line: topOfFile.line, character: topOfFile.character }).toEqual({ line: 0, character: 0 });
+});


### PR DESCRIPTION
Reference https://github.com/microsoft/playwright/issues/40226

## Summary
Users report the extension crashes with *"Illegal argument: character must be non-negative"* after a recent Windows update (25H2 / build 26200.8246), leaving no tests visible. The underlying trigger is a `connect ETIMEDOUT ::1:<port>` when the extension fails to connect to its spawned Playwright test server (likely OS-level IPv6/loopback change). That's a separate root cause — this PR is about the crash that follows.

When `listFiles()` throws, [`TestModel._listFiles`](src/testModel.ts#L216-L222) synthesizes a config error with `location: { file: configFile, line: 0, column: 0 }`. Downstream, [`TestTree._syncConfigErrors`](src/testTree.ts#L229) (and [`Extension._asPosition`](src/extension.ts#L1031)) did `column - 1` without clamping — producing `character = -1`, which VSCode's `Position` constructor rejects. Six uncaught errors per activation, one per surfaced error location.

- Clamp `column - 1` the same way `line - 1` was already clamped, at all three call sites that convert a Playwright error location into a `Position`.
- Tighten the `Position` mock in tests to reject negative line/character (matching real VSCode behavior), so any future regression is caught by the suite.
- Add a focused test in `problems.spec.ts` covering `column = 0`.

The underlying ETIMEDOUT is not addressed here — this fix just keeps the extension usable (diagnostic is shown, tests remain discoverable) instead of crashing silently when it happens.
