### PR TITLE
fix(extension): bind spawned servers to 127.0.0.1 instead of localhost

### DIFF
--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -319,7 +319,7 @@ export class PlaywrightTestServer {
           PWDEBUG: 'console',
         },
         program: paths.cli,
-        args: ['test-server', '-c', paths.config],
+        args: ['test-server', '-c', paths.config, '--host', '127.0.0.1'],
       });
 
       if (token?.isCancellationRequested)
@@ -408,6 +408,7 @@ export class PlaywrightTestServer {
         paths.cli,
         'test-server',
         '-c', paths.config,
+        '--host', '127.0.0.1',
       ],
       cwd: paths.cwd,
       envProvider: () => {

--- a/src/reusedBrowser.ts
+++ b/src/reusedBrowser.ts
@@ -91,7 +91,8 @@ export class ReusedBrowser implements vscodeTypes.Disposable {
     const args = [
       config.cli,
       'run-server',
-      `--path=/${createGuid()}`
+      `--path=/${createGuid()}`,
+      '--host', '127.0.0.1',
     ];
     const cwd = config.workspaceFolder;
     const envProvider = () => ({

--- a/tests/list-tests.spec.ts
+++ b/tests/list-tests.spec.ts
@@ -45,6 +45,30 @@ test('should list tests on expand', async ({ activate }) => {
   ]);
 });
 
+test('should spawn test-server bound to IPv4 loopback', async ({ activate }) => {
+  // Windows 11 25H2 broke the IPv6 loopback, leaving the extension unable to
+  // connect to its test server (`connect ETIMEDOUT ::1:<port>`). Forcing the
+  // server to bind to 127.0.0.1 avoids the IPv6 path entirely.
+  // See https://github.com/microsoft/playwright/issues/40226.
+  const { vscode, testController } = await activate({
+    'playwright.config.js': `module.exports = { testDir: 'tests' }`,
+    'tests/test.spec.ts': `
+      import { test } from '@playwright/test';
+      test('one', async () => {});
+    `,
+  });
+
+  await testController.expandTestItems(/test.spec.ts/);
+
+  const startServerLog = vscode.logOutputChannels
+      .flatMap(c => c.messages)
+      .find(m => m.args[0] === 'Starting test server');
+  expect(startServerLog, 'test server should have been spawned').toBeTruthy();
+  const args: string[] = startServerLog!.args[2];
+  expect(args).toContain('test-server');
+  expect(args).toEqual(expect.arrayContaining(['--host', '127.0.0.1']));
+});
+
 test('should list tests for visible editors', async ({ activate }) => {
   const { vscode, testController } = await activate({
     'playwright.config.js': `module.exports = { testDir: 'tests' }`,

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -923,11 +923,12 @@ type HoverProvider = {
 };
 
 class LogOutputChannel {
-  debug() {}
-  info() {}
-  warn() {}
-  error() {}
-  trace() {}
+  readonly messages: { level: string, args: any[] }[] = [];
+  debug(...args: any[]) { this.messages.push({ level: 'debug', args }); }
+  info(...args: any[]) { this.messages.push({ level: 'info', args }); }
+  warn(...args: any[]) { this.messages.push({ level: 'warn', args }); }
+  error(...args: any[]) { this.messages.push({ level: 'error', args }); }
+  trace(...args: any[]) { this.messages.push({ level: 'trace', args }); }
 }
 
 export class VSCode {
@@ -1000,6 +1001,7 @@ export class VSCode {
   readonly connectionLog: any[] = [];
   readonly openExternalUrls: string[] = [];
   readonly diagnosticsCollections: DiagnosticsCollection[] = [];
+  readonly logOutputChannels: LogOutputChannel[] = [];
   private _clipboardText = '';
 
   constructor(readonly versionNumber: number, baseDir: string, browser: Browser) {
@@ -1159,7 +1161,11 @@ export class VSCode {
         return { kind };
       },
     });
-    this.window.createOutputChannel = () => new LogOutputChannel();
+    this.window.createOutputChannel = () => {
+      const channel = new LogOutputChannel();
+      this.logOutputChannels.push(channel);
+      return channel;
+    };
 
     this.workspace.onDidChangeWorkspaceFolders = this.onDidChangeWorkspaceFolders;
     this.workspace.onDidChangeTextDocument = this.onDidChangeTextDocument;


### PR DESCRIPTION
Refs https://github.com/microsoft/playwright/issues/40226 (root-cause fix; companion to #768 which prevents the follow-on crash).

## Summary
Users started hitting `connect ETIMEDOUT ::1:<port>` after Windows 11 **25H2** (build 26200.8246), with matching reports on macOS. The extension spawns Playwright's `test-server` (and, for "reuse browser", `run-server`) without specifying `--host`. Both default to `localhost`, which Node resolves to `::1` first on dual-stack systems; the server binds IPv6-only, and something on 25H2 (firewall/WFP/MpsSvc defaults appear to be the culprit) then blocks the extension's IPv6 loopback connection.

- Pass `--host 127.0.0.1` to [`test-server`](src/playwrightTestServer.ts#L409) (listing + debug paths) and [`run-server`](src/reusedBrowser.ts#L91-L95). IPv4 loopback is reachable on all affected setups.
- No behavior change on systems that were already working — it just pins the bind address instead of relying on resolver order.
- Added [`tests/list-tests.spec.ts`](tests/list-tests.spec.ts) "should spawn test-server bound to IPv4 loopback" that asserts the spawn args via the captured log output channel. Verified the test fails when the `--host` arg is removed.

The existing `#768` defensively fixes the resulting `Position(-1)` crash; this PR removes the trigger.
