### PR TITLE
fix: forward error in TestServerTransport.onerror

### DIFF
--- a/src/playwrightTestServer.ts
+++ b/src/playwrightTestServer.ts
@@ -484,10 +484,10 @@ class TestServerTransportDebugger implements TestServerTransport {
     });
   }
 
-  onerror(listener: () => void): void {
-    this._inner.onerror(() => {
-      this._logger.debug('<-- transport error');
-      listener();
+  onerror(listener: (error: Error) => void): void {
+    this._inner.onerror(error => {
+      this._logger.debug('<-- transport error', error);
+      listener(error);
     });
   }
 

--- a/src/upstream/testServerConnection.ts
+++ b/src/upstream/testServerConnection.ts
@@ -28,7 +28,7 @@ export class TestServerConnectionClosedError extends Error {
 export interface TestServerTransport {
   onmessage(listener: (message: string) => void): void;
   onopen(listener: () => void): void;
-  onerror(listener: () => void): void;
+  onerror(listener: (error: Error) => void): void;
   onclose(listener: () => void): void;
 
   send(data: string): void;
@@ -50,8 +50,8 @@ export class WebSocketTestServerTransport implements TestServerTransport {
     this._ws.addEventListener('open', listener);
   }
 
-  onerror(listener: () => void) {
-    this._ws.addEventListener('error', listener);
+  onerror(listener: (error: Error) => void) {
+    this._ws.addEventListener('error', event => listener(new Error(event.message)));
   }
 
   onclose(listener: () => void) {


### PR DESCRIPTION
Users were reporting `Cannot read properties of undefined (reading 'message')` in https://github.com/Skn0tt/playwright-vscode/blob/8a56aab515b24d2786686758f3cb210bf0ede395/src/testModel.ts#L204, this fixes it. Regressed in #742.

Fixes https://github.com/microsoft/playwright/issues/40481