### PR TITLE
chore: roll playwright to 1.60.0-beta-1778518825000

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.23.2",
-        "@playwright/test": "1.60.0-beta-1778191499000",
+        "@playwright/test": "1.60.0-beta-1778518825000",
         "@types/babel__core": "^7.20.3",
         "@types/babel__helper-plugin-utils": "^7.10.2",
         "@types/babel__traverse": "^7.20.3",
@@ -1470,13 +1470,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-beta-1778191499000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-beta-1778191499000.tgz",
-      "integrity": "sha512-eJM7mWJvEfdJFLD9Hm+NZFeOliipw1mMLCtSX2HPeQoLw/jp58sxPQH2ldpchRTn0UMgDcuI0XKI24+8nLC1zA==",
+      "version": "1.60.0-beta-1778518825000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-beta-1778518825000.tgz",
+      "integrity": "sha512-MpCYnanAeJYD95hZtlYm0bBHxX5QY1LqKaDdf9EzOMqFvdV41sPokcTQL07UE3TCoEx2rSftKOuD5m/FaQcQkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-beta-1778191499000"
+        "playwright": "1.60.0-beta-1778518825000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5855,13 +5855,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-beta-1778191499000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-beta-1778191499000.tgz",
-      "integrity": "sha512-I4ZT4SFIrNdZAXmfDg8K67ya9uAs2ELqXfG0MA8ZcojDXyI6pWqIj2nnF/KqloGM++2ACvOa5MlII4Xa0c92/g==",
+      "version": "1.60.0-beta-1778518825000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-beta-1778518825000.tgz",
+      "integrity": "sha512-wKyEeqeNjxYfPk+LQt1/rWgPe0XhUw+ymnHa9w8ruW2N1pnzhPD9ioTQeFLld05dZ+mLqu69ZumiymAq9dl03Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-beta-1778191499000"
+        "playwright-core": "1.60.0-beta-1778518825000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5874,9 +5874,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-beta-1778191499000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-beta-1778191499000.tgz",
-      "integrity": "sha512-rN9NcOjAXvVf1qexgevYfRK8h4YhVRtu72tRcfcoU7aisGPSRIeoeGxozFYMjNPFWsJJEVsr3kkBYXuwKRPt7g==",
+      "version": "1.60.0-beta-1778518825000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-beta-1778518825000.tgz",
+      "integrity": "sha512-X/PCxX6TTHCB0T0HEkuW5QI0w8J8dIdfwPOWSO2MbWDcILPMsXdWup37/yBG/KtS1i4SwrzPJw/Jl07+b2Y2/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.23.2",
-        "@playwright/test": "1.59.0-beta-1774915887000",
+        "@playwright/test": "1.60.0-beta-1778191499000",
         "@types/babel__core": "^7.20.3",
         "@types/babel__helper-plugin-utils": "^7.10.2",
         "@types/babel__traverse": "^7.20.3",
@@ -1470,13 +1470,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.0-beta-1774915887000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.0-beta-1774915887000.tgz",
-      "integrity": "sha512-FIimSxS8watjnWsmHxyYexmWdODyWlURJfMdpvgE4FkIEsgNCk0iU9dv/loGDAtSBfDEAnGsd4lTxRUHsWCkiw==",
+      "version": "1.60.0-beta-1778191499000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-beta-1778191499000.tgz",
+      "integrity": "sha512-eJM7mWJvEfdJFLD9Hm+NZFeOliipw1mMLCtSX2HPeQoLw/jp58sxPQH2ldpchRTn0UMgDcuI0XKI24+8nLC1zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.0-beta-1774915887000"
+        "playwright": "1.60.0-beta-1778191499000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5855,13 +5855,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.0-beta-1774915887000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0-beta-1774915887000.tgz",
-      "integrity": "sha512-H2XT5IzMw3AAgdSMI+7ueUL4eZwDunz70ctAvtrIPsJKwUul5e3P+jPDhF3p+LqyxAz/3OLjwagq4hNcGSC6Uw==",
+      "version": "1.60.0-beta-1778191499000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-beta-1778191499000.tgz",
+      "integrity": "sha512-I4ZT4SFIrNdZAXmfDg8K67ya9uAs2ELqXfG0MA8ZcojDXyI6pWqIj2nnF/KqloGM++2ACvOa5MlII4Xa0c92/g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.0-beta-1774915887000"
+        "playwright-core": "1.60.0-beta-1778191499000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5874,9 +5874,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.0-beta-1774915887000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0-beta-1774915887000.tgz",
-      "integrity": "sha512-4gpxWN792J+pq0K82/zOphmhoPIxsXAkIS8ssvLQGzkSdLhetvIRKwiua1Ru/INkIuQngBUKQvRxZ73bLyFoiQ==",
+      "version": "1.60.0-beta-1778191499000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-beta-1778191499000.tgz",
+      "integrity": "sha512-rN9NcOjAXvVf1qexgevYfRK8h4YhVRtu72tRcfcoU7aisGPSRIeoeGxozFYMjNPFWsJJEVsr3kkBYXuwKRPt7g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.2",
-    "@playwright/test": "1.60.0-beta-1778191499000",
+    "@playwright/test": "1.60.0-beta-1778518825000",
     "@types/babel__core": "^7.20.3",
     "@types/babel__helper-plugin-utils": "^7.10.2",
     "@types/babel__traverse": "^7.20.3",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.2",
-    "@playwright/test": "1.59.0-beta-1774915887000",
+    "@playwright/test": "1.60.0-beta-1778191499000",
     "@types/babel__core": "^7.20.3",
     "@types/babel__helper-plugin-utils": "^7.10.2",
     "@types/babel__traverse": "^7.20.3",


### PR DESCRIPTION
## Summary
- Roll `@playwright/test` to `1.60.0-beta-1778518825000` (covers the recent v1.60 cherry-picks).

Part of https://github.com/microsoft/playwright-internal/issues/288.