### PR TITLE
fix: discover config even when hidden by files.exclude

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -310,7 +310,7 @@ export class Extension implements RunHooks {
     this._models.clear();
     this._testTree.startedLoading();
 
-    const configFiles = await this._vscode.workspace.findFiles('**/*playwright*.config.{ts,js,mts,mjs}', '**/node_modules/**', undefined, token);
+    const configFiles = await this._vscode.workspace.findFiles('**/*playwright*.config.{ts,js,mts,mjs}', null, undefined, token);
     if (token.isCancellationRequested)
       return;
 
@@ -319,6 +319,8 @@ export class Extension implements RunHooks {
     for (const configFileUri of configFiles) {
       const configFilePath = uriToPath(configFileUri);
       // TODO: parse .gitignore
+      if (configFilePath.includes('node_modules'))
+        continue;
       if (!this._isUnderTest && configFilePath.includes('test-results'))
         continue;
 

--- a/tests/mock/vscode.ts
+++ b/tests/mock/vscode.ts
@@ -1185,16 +1185,28 @@ export class VSCode {
       return document;
     };
 
-    this.workspace.findFiles = async (pattern: string) => {
+    this.workspace.findFiles = async (pattern: string, exclude?: string | null) => {
       const uris: Uri[] = [];
       for (const workspaceFolder of this.workspace.workspaceFolders) {
-        await new Promise<void>(f => {
-          const cwd = workspaceFolder.uri.fsPath;
-          glob(pattern, { cwd }, (err, files) => {
-            uris.push(...files.map(f => Uri.file(path.join(cwd, f))));
-            f();
-          });
+        const cwd = workspaceFolder.uri.fsPath;
+        const matchGlob = (g: string) => new Promise<string[]>(f => {
+          glob(g, { cwd }, (err, files) => f(files || []));
         });
+        const included = await matchGlob(pattern);
+        const excluded = new Set<string>();
+        if (exclude !== null) {
+          const filesExclude: Record<string, boolean> = this.workspace.getConfiguration('files').get('exclude') || {};
+          for (const [excludeGlob, enabled] of Object.entries(filesExclude)) {
+            if (!enabled)
+              continue;
+            for (const file of await matchGlob(excludeGlob))
+              excluded.add(file);
+          }
+        }
+        for (const file of included) {
+          if (!excluded.has(file))
+            uris.push(Uri.file(path.join(cwd, file)));
+        }
       }
       return uris;
     };

--- a/tests/track-configs.spec.ts
+++ b/tests/track-configs.spec.ts
@@ -202,3 +202,20 @@ test('git checkout should not lead to duplicate configs', { annotation: { type: 
     return testItems.map(i => i.label);
   }).toEqual(['playwright.config.js', 'playwright-two.config.js']);
 });
+
+test('should discover config hidden by files.exclude', async ({ activate }) => {
+  const { vscode, testController, workspaceFolder } = await activate({});
+
+  vscode.workspace.getConfiguration('files').update('exclude', { '**/*config*': true }, true);
+
+  await workspaceFolder.addFile('playwright.config.js', `module.exports = { testDir: 'tests' }`);
+  await workspaceFolder.addFile('tests/test.spec.ts', `
+    import { test } from '@playwright/test';
+    test('one', async () => {});
+  `);
+
+  await expect(testController).toHaveTestTree(`
+    -   tests
+      -   test.spec.ts
+  `);
+});


### PR DESCRIPTION
If a user's `files.exclude` matches their Playwright config (e.g. `"files.exclude": { "**/*config*": true }`), the extension reports "No Playwright tests found".

Turns out `findFiles` applies the user's `files.exclude`/`search.exclude` unless you pass `null` as the exclude arg. We were passing a glob string, so the config got hidden. This PR passes `null` instead - the config is machinery we need regardless of what's hidden in the file tree - and filters `node_modules` in the loop instead.

The `findFiles` mock now honours `files.exclude` like real VS Code, otherwise the bug isn't reproducible and the regression test would pass either way.

Also verified manually in VS Code with the failing setting - the tests show up now.

Closes https://github.com/microsoft/playwright/issues/41601