### PR TITLE
chore(debug-controller): send timeout metadata

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -107,7 +107,7 @@ export class BackendClient extends EventEmitter {
   send(method: string, params: any = {}): Promise<any> {
     return new Promise((fulfill, reject) => {
       const id = ++BackendClient._lastId;
-      const command = { id, guid: 'DebugController', method, params, metadata: {} };
+      const command = { id, guid: 'DebugController', method, params, metadata: { timeout: 0 } };
       this._transport.send(command as any);
       this._callbacks.set(id, { fulfill, reject });
     });


### PR DESCRIPTION
Adds `timeout: 0` to every `DebugController` request's metadata. This keeps the VS Code transport compatible once timeout metadata becomes required.