### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         - os: ubuntu-latest
           node-version: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
@@ -35,7 +35,7 @@ jobs:
     - run: npm run test
     - run: npx vsce package
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
       with:
         name: vsc-extension
@@ -51,12 +51,12 @@ jobs:
     env:
       DEBUG: pw:browser
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 20
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       with:
         version: 10
     - run: npm i -g yarn@1
@@ -83,7 +83,7 @@ jobs:
         PWTEST_BLOB_DO_NOT_REMOVE: 1
     - run: npx playwright merge-reports blob-report --reporter=html
       if: always()
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: always()
       with:
         name: playwright-report-${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         - os: ubuntu-latest
           node-version: 20
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
@@ -35,7 +35,7 @@ jobs:
     - run: npm run test
     - run: npx vsce package
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
       with:
         name: vsc-extension
@@ -51,9 +51,9 @@ jobs:
     env:
       DEBUG: pw:browser
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 20
     - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -83,7 +83,7 @@ jobs:
         PWTEST_BLOB_DO_NOT_REMOVE: 1
     - run: npx playwright merge-reports blob-report --reporter=html
       if: always()
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: playwright-report-${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Pins GitHub Actions in `.github/workflows/ci.yml` to full-length commit SHAs and adds a `github-actions` Dependabot entry with a 7-day cooldown. Replaces #803.
- Bumps the pinned versions of `actions/checkout` (v7.0.1), `actions/setup-node` (v6.5.0) and `actions/upload-artifact` (v7.0.1) to align with the SHAs used in the microsoft/playwright repo.